### PR TITLE
chore: update Pages artifact action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           # Upload dist repository
           path: './dist'


### PR DESCRIPTION
## Summary
- use `actions/upload-pages-artifact@v2` in deploy workflow to avoid deprecated `upload-artifact@v3`

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68966374d000832a9d261109586f789b