### PR TITLE
Fix deploy workflow: bump Node to 24 for Astro 7 compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
       - name: Install dependencies from lockfile
         run: npm ci


### PR DESCRIPTION
## Summary
- `deploy.yml` still set up Node 20, but Astro 7 requires Node >=22.12.0 (and `package.json`'s `engines` field pins >=24), so every deploy since PR #18 merged has failed at the build step with `Node.js v20.20.2 is not supported by Astro!`.
- Bumps `node-version` to 24 to match.

## Test plan
- [x] `npm run build` succeeds locally on Node 22+ (1122 pages built)