### PR TITLE
Fix header/footer edge padding, ragged card heights, footer pipes, and crafting grid

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.craftalog.app

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://www.craftalog.app",
+  site: "https://seriouslysean.github.io",
   base: process.env.BASE_PATH ?? "/",
   outDir: "./dist",
   prefetch: {

--- a/src/components/CraftingGrid.astro
+++ b/src/components/CraftingGrid.astro
@@ -18,11 +18,7 @@ const resultItem = result ? items.get(result.id) : undefined;
 ---
 
 <div class="crafting">
-  <div
-    class:list={['crafting__grid', { 'crafting__grid--unordered': unordered }]}
-    role="img"
-    aria-label={ariaLabel}
-  >
+  <div class="crafting__grid" role="img" aria-label={ariaLabel}>
     {
       unordered && (
         <svg
@@ -87,11 +83,11 @@ const resultItem = result ? items.get(result.id) : undefined;
   </div>
 </div>
 
-{unordered && <p class="crafting__caption">Place ingredients in any order.</p>}
+{unordered && <p class="crafting__caption">Order doesn&rsquo;t matter.</p>}
 
 <style>
   .crafting {
-    --crafting-cell: 4rem;
+    --crafting-cell: 3.5rem;
     display: flex;
     align-items: center;
     gap: var(--space-4);
@@ -118,11 +114,6 @@ const resultItem = result ? items.get(result.id) : undefined;
     color: var(--color-muted);
     border-radius: 999px;
     box-shadow: 0 0 0 1px var(--color-border);
-  }
-
-  .crafting__grid--unordered .crafting__cell {
-    outline: 2px dashed rgba(0, 0, 0, 0.35);
-    outline-offset: -2px;
   }
 
   .crafting__caption {

--- a/src/components/ItemIcon.astro
+++ b/src/components/ItemIcon.astro
@@ -21,9 +21,15 @@ const isBlock = item?.icon.type === 'block';
     <div class:list={['item-icon', { 'item-icon--block': isBlock }]}>
       {item.icon.type === 'block' ? (
         <ul class="block" role="img" aria-label={item.name} title={item.name}>
-          <li class="top" style={`background-image: url(${withBase(item.icon.top)})`} />
-          <li class="left" style={`background-image: url(${withBase(item.icon.side)})`} />
-          <li class="right" style={`background-image: url(${withBase(item.icon.side)})`} />
+          <li class="top">
+            <img src={withBase(item.icon.top)} alt="" loading={loading} decoding="async" />
+          </li>
+          <li class="left">
+            <img src={withBase(item.icon.side)} alt="" loading={loading} decoding="async" />
+          </li>
+          <li class="right">
+            <img src={withBase(item.icon.side)} alt="" loading={loading} decoding="async" />
+          </li>
         </ul>
       ) : (
         <img
@@ -32,6 +38,7 @@ const isBlock = item?.icon.type === 'block';
           alt={item.name}
           title={item.name}
           loading={loading}
+          decoding="async"
         />
       )}
     </div>
@@ -71,11 +78,17 @@ const isBlock = item?.icon.type === 'block';
   .block .top,
   .block .left,
   .block .right {
-    background: #fff none no-repeat center / cover;
+    background-color: #fff;
     width: 100%;
     height: 100%;
     position: absolute;
     display: flex;
+  }
+
+  .block img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 
   .left {

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -3,36 +3,51 @@ import meta from '../data/generated/meta.json';
 ---
 
 <footer>
-  <div class="footer-content">
-    <p>
-      Minecraft {meta.version} data | Made with &hearts; |
-      <a href="https://github.com/seriouslysean/craftalog">GitHub</a>
-    </p>
-  </div>
+  <p class="footer__text">
+    <span>Minecraft {meta.version} data</span>
+    <span class="footer__separator" aria-hidden="true">&middot;</span>
+    <span>Made with <span aria-hidden="true">&hearts;</span></span>
+    <span class="footer__separator" aria-hidden="true">&middot;</span>
+    <a href="https://github.com/seriouslysean/craftalog" class="footer__link">GitHub</a>
+  </p>
 </footer>
 
 <style>
   footer {
+    margin-top: auto;
     border-top: 1px solid var(--color-border);
   }
 
-  .footer-content {
+  .footer__text {
+    max-width: 60rem;
+    margin: 0 auto;
+    padding: var(--space-8) var(--space-4) var(--space-6);
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-  }
-
-  footer p {
+    gap: var(--space-2);
     font-size: 0.875rem;
     color: var(--color-muted);
   }
 
-  footer a {
+  @media (min-width: 640px) {
+    .footer__text {
+      padding-left: var(--space-8);
+      padding-right: var(--space-8);
+    }
+  }
+
+  .footer__separator {
+    color: var(--color-border);
+  }
+
+  .footer__link {
     color: var(--color-muted);
     border-bottom-color: transparent;
   }
 
-  footer a:hover {
+  .footer__link:hover {
     color: var(--color-fg);
     border-bottom-color: var(--color-fg);
   }

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -33,10 +33,20 @@ const isActive = (path: string) => {
   }
 
   .header-content {
+    max-width: 60rem;
+    margin: 0 auto;
+    padding: var(--space-6) var(--space-4);
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--space-4);
+  }
+
+  @media (min-width: 640px) {
+    .header-content {
+      padding-left: var(--space-8);
+      padding-right: var(--space-8);
+    }
   }
 
   .logo {

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -13,13 +13,13 @@ const { title, description } = Astro.props;
 
 <Layout title={title} description={description}>
   <div class="wrapper">
-    <SiteHeader class="header" />
+    <SiteHeader />
 
     <main class="main">
       <slot />
     </main>
 
-    <SiteFooter class="footer" />
+    <SiteFooter />
   </div>
 </Layout>
 
@@ -30,35 +30,15 @@ const { title, description } = Astro.props;
     min-height: 100vh;
   }
 
-  .header,
-  .main,
-  .footer {
+  .main {
     margin: 0 auto;
-    padding: 0 var(--space-4);
+    padding: var(--space-6) var(--space-4) var(--space-12);
     max-width: 60rem;
     width: 100%;
   }
 
-  .header {
-    padding-top: var(--space-6);
-    padding-bottom: var(--space-6);
-  }
-
-  .main {
-    padding-top: var(--space-6);
-    padding-bottom: var(--space-12);
-  }
-
-  .footer {
-    margin-top: auto;
-    padding-top: var(--space-8);
-    padding-bottom: var(--space-6);
-  }
-
   @media (min-width: 640px) {
-    .header,
-    .main,
-    .footer {
+    .main {
       padding-left: var(--space-8);
       padding-right: var(--space-8);
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -291,6 +291,11 @@ const totalRecipes = recipeEntries.length;
     gap: var(--space-2);
   }
 
+  .catalog__item {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 4.5rem;
+  }
+
   .catalog__link {
     display: flex;
     align-items: center;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -295,6 +295,7 @@ const totalRecipes = recipeEntries.length;
     display: flex;
     align-items: center;
     gap: var(--space-2);
+    height: 100%;
     min-height: 3.5rem;
     padding: var(--space-2) var(--space-3);
     border: 1px solid var(--color-border);


### PR DESCRIPTION
- SiteHeader/SiteFooter: class="header"/"footer" passed from MainLayout was
  never forwarded to the components' root elements (Astro doesn't do this
  automatically), so their padding/max-width rules were dead code and content
  sat flush against the viewport edges. Move the container constraints into
  each component's own inner wrapper instead.
- index.astro: catalog cards left ragged bottoms when a neighboring card's
  name wrapped to two lines, since the grid stretched the <li> to fill the
  row but the bordered <a> inside never grew to match. Add height: 100%.
- SiteFooter: replace the raw "|" separators (and a whitespace-collapse bug
  swallowing the space before "GitHub") with proper flex items and a subtle
  middot separator; align classnames to BEM.
- CraftingGrid: drop the dashed cell-outline treatment for shapeless/
  transmute recipes (redundant with the existing shuffle icon + caption, and
  looked noisy applied across all 9 cells including empty ones); simplify the
  caption copy. Also shrink the mobile crafting-cell size slightly so the
  grid/arrow/result row doesn't silently wrap on common phone widths.
- ItemIcon: convert the pseudo-3D block faces from CSS background-image to
  real <img> elements so they get native lazy-loading like the flat icons
  already did (background-image has no loading attribute equivalent).