### PR TITLE
Move shape/shapeless indicator out of the grid, redesign ingredient options

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -1,0 +1,38 @@
+---
+interface Props {
+  /** `gui` styles the badge with the Minecraft panel palette, for recipe-mechanical
+   * facts (shapeless, transmute) as distinct from taxonomy (category, group). */
+  variant?: 'default' | 'gui';
+  title?: string;
+}
+
+const { variant = 'default', title } = Astro.props;
+---
+
+<span class:list={['badge', `badge--${variant}`]} title={title}>
+  <slot />
+</span>
+
+<style>
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+    padding: var(--space-1) var(--space-3);
+    border-radius: var(--radius-pill);
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: capitalize;
+  }
+
+  .badge--default {
+    background-color: var(--color-border);
+    color: var(--color-fg);
+  }
+
+  .badge--gui {
+    background-color: var(--color-panel);
+    color: var(--color-panel-fg);
+    text-transform: none;
+  }
+</style>

--- a/src/components/CraftingGrid.astro
+++ b/src/components/CraftingGrid.astro
@@ -1,6 +1,7 @@
 ---
 import ItemIcon from './ItemIcon.astro';
 import ItemStat from './ItemStat.astro';
+import ItemVariants from './ItemVariants.astro';
 import type { GridCell } from '../utils/crafting-grid';
 import type { ItemData, RecipeResult } from '../content.config';
 
@@ -9,58 +10,18 @@ interface Props {
   result?: RecipeResult;
   items: Map<string, ItemData>;
   ariaLabel: string;
-  /** Shapeless/transmute recipes: ingredient placement in the grid doesn't matter. */
-  unordered?: boolean;
 }
 
-const { cells, result, items, ariaLabel, unordered = false } = Astro.props;
+const { cells, result, items, ariaLabel } = Astro.props;
 const resultItem = result ? items.get(result.id) : undefined;
 ---
 
 <div class="crafting">
   <div class="crafting__grid" role="img" aria-label={ariaLabel}>
     {
-      unordered && (
-        <svg
-          class="crafting__shuffle-icon"
-          viewBox="0 0 24 24"
-          width="16"
-          height="16"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M16 3h5v5" />
-          <path d="M4 20 21 3" />
-          <path d="M21 16v5h-5" />
-          <path d="M15 15l6 6" />
-          <path d="M4 4l5 5" />
-        </svg>
-      )
-    }
-    {
       cells.map((cell, index) => (
         <div class="crafting__cell" data-index={index}>
-          {cell && (
-            <div
-              class="crafting__variants"
-              data-variant-count={cell.items.length > 1 ? cell.items.length : undefined}
-            >
-              {cell.items.map((itemId: string, variantIndex: number) => {
-                const variantItem = items.get(itemId);
-                return (
-                  variantItem && (
-                    <div class="crafting__variant" hidden={variantIndex !== 0}>
-                      <ItemIcon item={variantItem} loading="eager" />
-                    </div>
-                  )
-                );
-              })}
-            </div>
-          )}
+          {cell && <ItemVariants items={cell.items} itemsMap={items} loading="eager" />}
         </div>
       ))
     }
@@ -83,43 +44,24 @@ const resultItem = result ? items.get(result.id) : undefined;
   </div>
 </div>
 
-{unordered && <p class="crafting__caption">Order doesn&rsquo;t matter.</p>}
-
 <style>
   .crafting {
     --crafting-cell: 3.5rem;
     display: flex;
     align-items: center;
     gap: var(--space-4);
-    background-color: var(--color-gray-light);
+    background-color: var(--color-panel);
     padding: var(--space-4);
-    border-radius: 0.5rem;
+    border-radius: var(--radius-md);
+    box-shadow: var(--bevel-raised);
     flex-wrap: wrap;
   }
 
   .crafting__grid {
-    position: relative;
     display: grid;
     grid-template-columns: repeat(3, var(--crafting-cell));
     grid-auto-rows: var(--crafting-cell);
     gap: var(--space-2);
-  }
-
-  .crafting__shuffle-icon {
-    position: absolute;
-    top: -0.5rem;
-    right: -0.5rem;
-    padding: 0.2rem;
-    background-color: var(--color-bg);
-    color: var(--color-muted);
-    border-radius: 999px;
-    box-shadow: 0 0 0 1px var(--color-border);
-  }
-
-  .crafting__caption {
-    margin-top: var(--space-3);
-    font-size: 0.8125rem;
-    color: var(--color-muted);
   }
 
   .crafting__arrow {
@@ -135,29 +77,13 @@ const resultItem = result ? items.get(result.id) : undefined;
   .crafting__cell {
     width: var(--crafting-cell);
     height: var(--crafting-cell);
-    background-color: var(--color-gray);
-    box-shadow:
-      0.4em 0.4em 0 0 rgba(0, 0, 0, 0.5) inset,
-      -0.4em -0.4em 0 0 rgba(255, 255, 255, 0.75) inset;
+    background-color: var(--color-slot);
+    box-shadow: var(--bevel-sunken);
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
     padding: var(--space-2);
-  }
-
-  .crafting__variants {
-    position: relative;
-    width: 100%;
-    height: 100%;
-  }
-
-  .crafting__variant {
-    position: absolute;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 
   .crafting__count {
@@ -181,37 +107,3 @@ const resultItem = result ? items.get(result.id) : undefined;
     }
   }
 </style>
-
-<script>
-  const TICK_MS = 1500;
-  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-  function cycleVariants() {
-    document
-      .querySelectorAll<HTMLElement>('.crafting__variants[data-variant-count]')
-      .forEach((wrapper) => {
-        const count = Number(wrapper.dataset.variantCount);
-        if (!count || count < 2) return;
-
-        const variants = wrapper.querySelectorAll<HTMLElement>('.crafting__variant');
-        const currentIndex = Array.from(variants).findIndex((variant) => !variant.hidden);
-        const nextIndex = (currentIndex + 1) % variants.length;
-
-        variants.forEach((variant, index) => {
-          variant.hidden = index !== nextIndex;
-        });
-      });
-  }
-
-  // Module scope persists across View Transitions navigations (the script
-  // isn't re-executed, only astro:page-load re-fires below), so the previous
-  // page's interval must be cleared or they'd stack up on every navigation.
-  let intervalId: ReturnType<typeof setInterval> | undefined;
-
-  document.addEventListener('astro:page-load', () => {
-    clearInterval(intervalId);
-    if (!prefersReducedMotion) {
-      intervalId = setInterval(cycleVariants, TICK_MS);
-    }
-  });
-</script>

--- a/src/components/IngredientOptions.astro
+++ b/src/components/IngredientOptions.astro
@@ -1,0 +1,107 @@
+---
+import ItemVariants from './ItemVariants.astro';
+import type { ItemData } from '../content.config';
+import type { IngredientOption } from '../utils/tag-label';
+
+interface Props {
+  entries: IngredientOption[];
+  itemsMap: Map<string, ItemData>;
+  /** Extra recipe-mechanical note (e.g. transmute's contents/appearance rule). */
+  note?: string;
+}
+
+const { entries, itemsMap, note } = Astro.props;
+---
+
+{
+  (entries.length > 0 || note) && (
+    <section class="ingredient-options" aria-label="Ingredient options">
+      {entries.length > 0 && (
+        <>
+          <h2 class="ingredient-options__title">Accepts any of these</h2>
+          <ul class="ingredient-options__list">
+            {entries.map((entry) => (
+              <li class="ingredient-options__row">
+                <span class="ingredient-options__slot">
+                  <ItemVariants items={entry.items} itemsMap={itemsMap} />
+                </span>
+                <span class="ingredient-options__label">{entry.label}</span>
+                <span class="ingredient-options__count">{entry.items.length} options</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {note && <p class="ingredient-options__note">{note}</p>}
+    </section>
+  )
+}
+
+<style>
+  .ingredient-options {
+    margin-top: var(--space-2);
+    background-color: var(--color-panel);
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius-md);
+    box-shadow: var(--bevel-raised);
+  }
+
+  .ingredient-options__title {
+    margin: 0;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-panel-fg);
+  }
+
+  .ingredient-options__list {
+    margin-top: var(--space-2);
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .ingredient-options__row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .ingredient-options__slot {
+    position: relative;
+    flex-shrink: 0;
+    width: 2.25rem;
+    height: 2.25rem;
+    font-size: 0.7em;
+    background-color: var(--color-slot);
+    box-shadow: var(--bevel-sunken);
+  }
+
+  .ingredient-options__label {
+    font-size: 0.875rem;
+    color: var(--color-panel-fg);
+  }
+
+  .ingredient-options__count {
+    margin-left: auto;
+    font-size: 0.75rem;
+    color: var(--color-panel-fg);
+    opacity: 0.75;
+  }
+
+  .ingredient-options__note {
+    margin-top: var(--space-3);
+    font-size: 0.8125rem;
+    color: var(--color-panel-fg);
+  }
+
+  .ingredient-options__note:first-child {
+    margin-top: 0;
+  }
+
+  @media (min-width: 640px) {
+    .ingredient-options__list {
+      grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    }
+  }
+</style>

--- a/src/components/ItemVariants.astro
+++ b/src/components/ItemVariants.astro
@@ -1,0 +1,76 @@
+---
+import ItemIcon from './ItemIcon.astro';
+import type { ItemData } from '../content.config';
+
+interface Props {
+  /** Item ids this slot accepts; cycles between them when there's more than one. */
+  items: string[];
+  itemsMap: Map<string, ItemData>;
+  loading?: 'lazy' | 'eager';
+}
+
+const { items, itemsMap, loading = 'lazy' } = Astro.props;
+---
+
+<span class="item-variants" data-variant-cycle={items.length > 1 ? items.length : undefined}>
+  {
+    items.map((itemId, index) => {
+      const item = itemsMap.get(itemId);
+      return (
+        item && (
+          <span class="item-variants__variant" hidden={index !== 0}>
+            <ItemIcon item={item} loading={loading} />
+          </span>
+        )
+      );
+    })
+  }
+</span>
+
+<style>
+  .item-variants {
+    position: relative;
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .item-variants__variant {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>
+
+<script>
+  const TICK_MS = 1500;
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  function cycleVariants() {
+    document
+      .querySelectorAll<HTMLElement>('.item-variants[data-variant-cycle]')
+      .forEach((wrapper) => {
+        const variants = wrapper.querySelectorAll<HTMLElement>('.item-variants__variant');
+        const currentIndex = Array.from(variants).findIndex((variant) => !variant.hidden);
+        const nextIndex = (currentIndex + 1) % variants.length;
+
+        variants.forEach((variant, index) => {
+          variant.hidden = index !== nextIndex;
+        });
+      });
+  }
+
+  // Module scope persists across View Transitions navigations (the script
+  // isn't re-executed, only astro:page-load re-fires below), so the previous
+  // page's interval must be cleared or they'd stack up on every navigation.
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+
+  document.addEventListener('astro:page-load', () => {
+    clearInterval(intervalId);
+    if (!prefersReducedMotion) {
+      intervalId = setInterval(cycleVariants, TICK_MS);
+    }
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -53,6 +53,24 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     --color-border: #e4e4e7;
     --color-muted: #71717a;
 
+    /* Minecraft GUI system: panels/slots for recipe-mechanical surfaces
+       (crafting grid, ingredient options), kept distinct from the clean
+       neutral chrome (nav, buttons, catalog pills). */
+    --color-panel: var(--color-gray-light);
+    --color-panel-fg: var(--color-gray-dark);
+    --color-slot: var(--color-gray);
+    --bevel-highlight: rgba(255, 255, 255, 0.75);
+    --bevel-shadow: rgba(0, 0, 0, 0.5);
+    --bevel-sunken:
+      0.4em 0.4em 0 0 var(--bevel-shadow) inset, -0.4em -0.4em 0 0 var(--bevel-highlight) inset;
+    --bevel-raised:
+      -0.15em -0.15em 0 0 var(--bevel-shadow) inset, 0.15em 0.15em 0 0 var(--bevel-highlight) inset;
+
+    /* Shape */
+    --radius-sm: 0.375rem;
+    --radius-md: 0.5rem;
+    --radius-pill: 999px;
+
     /* Spacing */
     --space-1: 0.25rem;
     --space-2: 0.5rem;
@@ -136,5 +154,14 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
   img {
     display: block;
     max-inline-size: 100%;
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -215,7 +215,7 @@ const totalRecipes = recipeEntries.length;
     max-width: 24rem;
     padding: var(--space-2) var(--space-3);
     border: 1px solid var(--color-border);
-    border-radius: 0.375rem;
+    border-radius: var(--radius-sm);
     font-size: 1rem;
     font-family: var(--font-sans);
   }
@@ -246,7 +246,7 @@ const totalRecipes = recipeEntries.length;
     gap: 0.25em;
     padding: var(--space-1) var(--space-3);
     border: 1px solid var(--color-border);
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     font-size: 0.8125rem;
     color: var(--color-muted);
     cursor: pointer;
@@ -304,7 +304,7 @@ const totalRecipes = recipeEntries.length;
     min-height: 3.5rem;
     padding: var(--space-2) var(--space-3);
     border: 1px solid var(--color-border);
-    border-radius: 0.375rem;
+    border-radius: var(--radius-sm);
     transition: all 0.2s;
   }
 

--- a/src/pages/recipe/[id].astro
+++ b/src/pages/recipe/[id].astro
@@ -1,11 +1,13 @@
 ---
 import { getCollection } from 'astro:content';
 import MainLayout from '../../layouts/MainLayout.astro';
+import Badge from '../../components/Badge.astro';
 import CraftingGrid from '../../components/CraftingGrid.astro';
+import IngredientOptions from '../../components/IngredientOptions.astro';
 import ItemIcon from '../../components/ItemIcon.astro';
 import ItemStat from '../../components/ItemStat.astro';
 import { buildShapedGrid, buildShapelessGrid, type GridCell } from '../../utils/crafting-grid';
-import { ingredientLabel } from '../../utils/tag-label';
+import { ingredientOption, type IngredientOption } from '../../utils/tag-label';
 import { withBase } from '../../utils/with-base';
 import type { ItemData, RecipeData } from '../../content.config';
 
@@ -58,24 +60,25 @@ if (recipe.type === 'shaped' && recipe.pattern && recipe.key) {
 }
 
 const hasGrid = recipe.type !== 'special';
+const isShapeless = recipe.type === 'shapeless' || recipe.type === 'transmute';
 
-interface LegendEntry {
-  symbol?: string;
-  label: string;
-}
-
-const legend: LegendEntry[] = [];
+const ingredientOptions: IngredientOption[] = [];
 if (recipe.type === 'shaped' && recipe.key) {
-  for (const [symbol, ingredient] of Object.entries(recipe.key)) {
-    const label = ingredientLabel(ingredient, getItemName);
-    if (label) legend.push({ symbol, label });
+  for (const ingredient of Object.values(recipe.key)) {
+    const option = ingredientOption(ingredient, getItemName);
+    if (option) ingredientOptions.push(option);
   }
 } else if (recipe.ingredients) {
   for (const ingredient of recipe.ingredients) {
-    const label = ingredientLabel(ingredient, getItemName);
-    if (label) legend.push({ label });
+    const option = ingredientOption(ingredient, getItemName);
+    if (option) ingredientOptions.push(option);
   }
 }
+
+const transmuteNote =
+  recipe.type === 'transmute'
+    ? "The result keeps the input item's contents/appearance."
+    : undefined;
 
 const ingredientNames = cells
   .filter((cell): cell is NonNullable<GridCell> => cell !== null)
@@ -120,19 +123,37 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
         </button>
       </div>
       <div class="recipe__badges">
-        <span class="recipe__badge">{categoryLabel}</span>
         {
-          recipe.group && (
-            <span class="recipe__badge recipe__badge--group">
-              {recipe.group.replace(/_/g, ' ')}
-            </span>
+          isShapeless && (
+            <Badge variant="gui" title="Ingredient placement in the grid doesn't matter">
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M16 3h5v5" />
+                <path d="M4 20 21 3" />
+                <path d="M21 16v5h-5" />
+                <path d="M15 15l6 6" />
+                <path d="M4 4l5 5" />
+              </svg>
+              Shapeless
+              <span class="visually-hidden">
+                {' '}
+                — ingredient placement in the grid doesn't matter
+              </span>
+            </Badge>
           )
         }
-        {
-          recipe.type === 'transmute' && (
-            <span class="recipe__badge recipe__badge--type">Transmute</span>
-          )
-        }
+        <Badge>{categoryLabel}</Badge>
+        {recipe.group && <Badge>{recipe.group.replace(/_/g, ' ')}</Badge>}
+        {recipe.type === 'transmute' && <Badge variant="gui">Transmute</Badge>}
       </div>
     </div>
 
@@ -144,24 +165,9 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
             result={recipe.result}
             items={itemsMap}
             ariaLabel={ariaLabel}
-            unordered={recipe.type === 'shapeless' || recipe.type === 'transmute'}
           />
 
-          {recipe.type === 'transmute' && (
-            <p class="recipe__note">The result keeps the input item's contents/appearance.</p>
-          )}
-
-          {legend.length > 0 && (
-            <ul class="recipe__legend">
-              {legend.map((item) => (
-                <li class="recipe__legend-item">
-                  {item.symbol && <span class="recipe__legend-symbol">{item.symbol}</span>}
-                  {item.symbol && ' = '}
-                  {item.label}
-                </li>
-              ))}
-            </ul>
-          )}
+          <IngredientOptions entries={ingredientOptions} itemsMap={itemsMap} note={transmuteNote} />
         </>
       ) : (
         <div class="recipe__special">
@@ -236,7 +242,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     gap: var(--space-1);
     padding: var(--space-1) var(--space-3);
     border: 1px solid var(--color-border);
-    border-radius: 0.375rem;
+    border-radius: var(--radius-sm);
     background: none;
     font-family: var(--font-sans);
     font-size: 0.8125rem;
@@ -268,49 +274,20 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     gap: var(--space-2);
   }
 
-  .recipe__badge {
-    display: inline-block;
-    padding: var(--space-1) var(--space-3);
-    border-radius: 999px;
-    background-color: var(--color-border);
-    font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: capitalize;
-  }
-
-  .recipe__badge--type {
-    background-color: var(--color-gray-light);
-    text-transform: none;
-  }
-
   .recipe__note {
     margin-top: var(--space-4);
     max-width: 40rem;
     color: var(--color-muted);
   }
 
-  .recipe__legend {
-    margin-top: var(--space-4);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-    font-size: 0.875rem;
-    color: var(--color-muted);
-  }
-
-  .recipe__legend-symbol {
-    font-family: var(--font-mono);
-    font-weight: 700;
-    color: var(--color-fg);
-  }
-
   .recipe__special {
     display: flex;
     align-items: center;
     gap: var(--space-4);
-    background-color: var(--color-gray-light);
+    background-color: var(--color-panel);
     padding: var(--space-4);
-    border-radius: 0.5rem;
+    border-radius: var(--radius-md);
+    box-shadow: var(--bevel-raised);
   }
 
   .recipe__special-icon {
@@ -320,6 +297,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 
   .recipe__special .recipe__note {
     margin-top: 0;
+    color: var(--color-panel-fg);
   }
 
   .recipe__pager {

--- a/src/utils/tag-label.ts
+++ b/src/utils/tag-label.ts
@@ -12,26 +12,31 @@ export function humanizeTagLabel(tag: string): string {
   return `Any ${words.join(" ")}`;
 }
 
+export interface IngredientOption {
+  label: string;
+  /** Every item id this ingredient accepts, for a cycling icon display. */
+  items: string[];
+}
+
 /**
- * Builds the label shown under the grid for a multi-option ingredient.
- * Returns `null` for single-item ingredients (nothing to label).
+ * Builds the label + variant items shown for a multi-option ingredient.
+ * Returns `null` for single-item ingredients (nothing to show).
  *
  * - Tag-based (e.g. "planks"): humanized tag, "Any Planks".
- * - Non-tag multi-option: first item's name + "or N more".
+ * - Non-tag multi-option: first item's name (the cycling icon + option
+ *   count carry the "or others" information, so the label doesn't need to).
  */
-export function ingredientLabel(
+export function ingredientOption(
   ingredient: Ingredient,
   getItemName: (id: string) => string,
-): string | null {
+): IngredientOption | null {
   if (ingredient.items.length <= 1) {
     return null;
   }
 
-  if (ingredient.tag) {
-    return humanizeTagLabel(ingredient.tag);
-  }
+  const label = ingredient.tag
+    ? humanizeTagLabel(ingredient.tag)
+    : getItemName(ingredient.items[0]);
 
-  const first = getItemName(ingredient.items[0]);
-  const more = ingredient.items.length - 1;
-  return `${first} or ${more} more`;
+  return { label, items: ingredient.items };
 }

--- a/tests/tag-label.test.ts
+++ b/tests/tag-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { humanizeTagLabel, ingredientLabel } from "../src/utils/tag-label";
+import { humanizeTagLabel, ingredientOption } from "../src/utils/tag-label";
 
 const itemName = (id: string) => id.charAt(0).toUpperCase() + id.slice(1).replace(/_/g, " ");
 
@@ -17,26 +17,34 @@ describe("humanizeTagLabel", () => {
   });
 });
 
-describe("ingredientLabel", () => {
-  it("returns null for a single-item ingredient (nothing to label)", () => {
-    expect(ingredientLabel({ items: ["stick"] }, itemName)).toBeNull();
+describe("ingredientOption", () => {
+  it("returns null for a single-item ingredient (nothing to show)", () => {
+    expect(ingredientOption({ items: ["stick"] }, itemName)).toBeNull();
   });
 
   it("labels a tag-based multi-option ingredient with the humanized tag", () => {
-    expect(
-      ingredientLabel({ items: ["oak_planks", "spruce_planks"], tag: "planks" }, itemName),
-    ).toBe("Any Planks");
+    const ingredient = { items: ["oak_planks", "spruce_planks"], tag: "planks" };
+    expect(ingredientOption(ingredient, itemName)).toEqual({
+      label: "Any Planks",
+      items: ["oak_planks", "spruce_planks"],
+    });
   });
 
-  it('labels a non-tag multi-option ingredient with the first item + "or N more"', () => {
+  it("labels a non-tag multi-option ingredient with the first item's name", () => {
     const ingredient = { items: ["coal", "charcoal"] };
-    expect(ingredientLabel(ingredient, itemName)).toBe("Coal or 1 more");
+    expect(ingredientOption(ingredient, itemName)).toEqual({
+      label: "Coal",
+      items: ["coal", "charcoal"],
+    });
   });
 
-  it('counts "or N more" correctly for many variants', () => {
+  it("keeps every item id for the cycling display, not just the first", () => {
     const ingredient = {
       items: ["white_bed", "orange_bed", "magenta_bed", "light_blue_bed"],
     };
-    expect(ingredientLabel(ingredient, itemName)).toBe("White bed or 3 more");
+    expect(ingredientOption(ingredient, itemName)).toEqual({
+      label: "White bed",
+      items: ["white_bed", "orange_bed", "magenta_bed", "light_blue_bed"],
+    });
   });
 });


### PR DESCRIPTION
The shuffle icon overlapping a grid cell and the "Order doesn't matter" +
bullet-list legend below it read as an afterthought bolted onto an
otherwise Minecraft-authentic crafting grid. A "Shapeless" badge now
lives with the other recipe badges near the title, and the multi-option
ingredients render as a beveled GUI panel of cycling item slots (synced
with the grid's own cycling) instead of plain text.

Extracts ItemVariants (the cycling-icon wrapper, now shared by the grid
and the panel instead of duplicated), Badge, and IngredientOptions as
reusable components, and adds panel/bevel/radius design tokens to
Layout.astro so the rest of the app can draw from the same GUI grammar
as the grid.