### PR TITLE
Fix button chrome, panel bevel, mobile grid wrap, and recipe page nav

### DIFF
--- a/src/components/CraftingGrid.astro
+++ b/src/components/CraftingGrid.astro
@@ -27,20 +27,22 @@ const resultItem = result ? items.get(result.id) : undefined;
     }
   </div>
 
-  <div class="crafting__arrow" aria-hidden="true">→</div>
+  <div class="crafting__output">
+    <div class="crafting__arrow" aria-hidden="true">→</div>
 
-  <div class="crafting__result">
-    <div class="crafting__cell">
-      {
-        resultItem && (
-          <>
-            <ItemIcon item={resultItem} loading="eager" />
-            {result && result.count > 1 && <span class="crafting__count">×{result.count}</span>}
-          </>
-        )
-      }
+    <div class="crafting__result">
+      <div class="crafting__cell">
+        {
+          resultItem && (
+            <>
+              <ItemIcon item={resultItem} loading="eager" />
+              {result && result.count > 1 && <span class="crafting__count">×{result.count}</span>}
+            </>
+          )
+        }
+      </div>
+      {resultItem?.stat && <ItemStat stat={resultItem.stat} />}
     </div>
-    {resultItem?.stat && <ItemStat stat={resultItem.stat} />}
   </div>
 </div>
 
@@ -51,11 +53,8 @@ const resultItem = result ? items.get(result.id) : undefined;
     align-items: center;
     gap: var(--space-4);
     background-color: var(--color-panel);
-    padding: var(--space-4);
-    border: var(--panel-border-width) solid;
-    border-color: var(--panel-border-color);
-    border-radius: var(--radius-md);
-    box-shadow: var(--panel-border-outer);
+    padding: calc(var(--space-4) + var(--panel-border-width));
+    box-shadow: var(--bevel-panel), var(--panel-border-outer);
     flex-wrap: wrap;
   }
 
@@ -64,6 +63,13 @@ const resultItem = result ? items.get(result.id) : undefined;
     grid-template-columns: repeat(3, var(--crafting-cell));
     grid-auto-rows: var(--crafting-cell);
     gap: var(--space-4);
+  }
+
+  .crafting__output {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    flex-shrink: 0;
   }
 
   .crafting__arrow {

--- a/src/components/CraftingGrid.astro
+++ b/src/components/CraftingGrid.astro
@@ -50,12 +50,16 @@ const resultItem = result ? items.get(result.id) : undefined;
   .crafting {
     --crafting-cell: 4rem;
     display: flex;
+    /* Mobile: grid stacked above the arrow+result, always centered -- a
+       fixed direction switch at the same breakpoint as --crafting-cell,
+       not flex-wrap, so the layout never depends on guessing whether
+       everything happens to fit on one line at a given viewport width. */
+    flex-direction: column;
     align-items: center;
     gap: var(--space-4);
     background-color: var(--color-panel);
     padding: calc(var(--space-4) + var(--panel-border-width));
     box-shadow: var(--bevel-panel), var(--panel-border-outer);
-    flex-wrap: wrap;
   }
 
   .crafting__grid {
@@ -76,6 +80,9 @@ const resultItem = result ? items.get(result.id) : undefined;
     font-size: 1.5rem;
     color: var(--color-muted);
     flex-shrink: 0;
+    /* Points down while the output sits below the grid on mobile; flipped
+       back to pointing right once the layout goes side-by-side. */
+    transform: rotate(90deg);
   }
 
   .crafting__result {
@@ -112,7 +119,12 @@ const resultItem = result ? items.get(result.id) : undefined;
   @media (min-width: 640px) {
     .crafting {
       --crafting-cell: 6rem;
+      flex-direction: row;
       gap: var(--space-6);
+    }
+
+    .crafting__arrow {
+      transform: none;
     }
   }
 </style>

--- a/src/components/IngredientOptions.astro
+++ b/src/components/IngredientOptions.astro
@@ -39,7 +39,7 @@ const { entries, itemsMap, note } = Astro.props;
 
 <style>
   .ingredient-options {
-    margin-top: var(--space-2);
+    margin-top: var(--space-6);
     background-color: var(--color-panel);
     padding: calc(var(--space-3) + var(--panel-border-width))
       calc(var(--space-4) + var(--panel-border-width));

--- a/src/components/IngredientOptions.astro
+++ b/src/components/IngredientOptions.astro
@@ -41,11 +41,9 @@ const { entries, itemsMap, note } = Astro.props;
   .ingredient-options {
     margin-top: var(--space-2);
     background-color: var(--color-panel);
-    padding: var(--space-3) var(--space-4);
-    border: var(--panel-border-width) solid;
-    border-color: var(--panel-border-color);
-    border-radius: var(--radius-md);
-    box-shadow: var(--panel-border-outer);
+    padding: calc(var(--space-3) + var(--panel-border-width))
+      calc(var(--space-4) + var(--panel-border-width));
+    box-shadow: var(--bevel-panel), var(--panel-border-outer);
   }
 
   .ingredient-options__title {

--- a/src/components/ItemCard.astro
+++ b/src/components/ItemCard.astro
@@ -1,0 +1,65 @@
+---
+import ItemIcon from './ItemIcon.astro';
+import type { ItemData } from '../content.config';
+
+interface Props {
+  href: string;
+  item: ItemData | null;
+  name: string;
+  /** Small caption under the name -- e.g. a disambiguating recipe subtitle
+      on the catalog, or "Previous"/"Next" on the recipe pager. */
+  subtitle?: string | null;
+  class?: string;
+}
+
+const { href, item, name, subtitle, class: className } = Astro.props;
+---
+
+<a href={href} class:list={['item-card', 'link-chip', className]}>
+  <span class="item-card__icon">
+    <ItemIcon item={item} />
+  </span>
+  <span class="item-card__text">
+    <span class="item-card__name">{name}</span>
+    {subtitle && <span class="item-card__subtitle">{subtitle}</span>}
+  </span>
+</a>
+
+<style>
+  .item-card {
+    color: var(--color-panel-fg);
+  }
+
+  .item-card:focus-visible {
+    outline: 2px solid var(--color-fg);
+    outline-offset: 2px;
+  }
+
+  .item-card__icon {
+    display: block;
+    width: 2rem;
+    flex-shrink: 0;
+    image-rendering: pixelated;
+  }
+
+  .item-card__text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    gap: 0.125rem;
+  }
+
+  .item-card__name {
+    font-size: 0.875rem;
+    text-wrap: balance;
+  }
+
+  .item-card__subtitle {
+    font-size: 0.75rem;
+    color: var(--color-muted);
+    text-transform: capitalize;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -81,6 +81,14 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
       -0.5em -0.5em 0 0 rgba(0, 0, 0, 0.5) inset, 0.5em 0.5em 0 0 rgba(255, 255, 255, 0.75) inset;
     --bevel-button-pressed:
       0.5em 0.5em 0 0 rgba(0, 0, 0, 0.5) inset, -0.5em -0.5em 0 0 rgba(255, 255, 255, 0.75) inset;
+    /* Same raised-bevel direction as --bevel-button, but in fixed rem units
+       (not em) and offset by --panel-border-width -- used by large panels
+       (crafting grid, ingredient options, special recipe box) so their
+       "border" is the same stepped-pixel block as the small button/slot
+       bevels, not a mitered border-color trick. */
+    --bevel-panel:
+      -0.5rem -0.5rem 0 0 rgba(0, 0, 0, 0.5) inset,
+      0.5rem 0.5rem 0 0 rgba(255, 255, 255, 0.75) inset;
 
     /* Shape */
     --radius-sm: 0.125rem;
@@ -90,13 +98,10 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     --border-width: 0.125rem;
 
     /* Larger panels (crafting grid, ingredient options, special recipe box):
-       a chunky border as thick as the grid cells' own bevel offset (0.5em,
-       matches --bevel-slot/--bevel-button), white on the top/left and dark
-       on the bottom/right -- the same raised-bevel direction as the cells
-       and buttons, just drawn as a real border instead of a box-shadow --
-       plus a thin darker-gray ring just outside it. */
+       drawn with --bevel-panel (see above) at this thickness -- panels pad
+       their content by this amount extra so the bevel has room to sit
+       inside the padding box -- plus a thin darker-gray ring just outside. */
     --panel-border-width: 0.5rem;
-    --panel-border-color: #fff var(--color-gray-dark) var(--color-gray-dark) #fff;
     --panel-border-outer-width: 0.125rem;
     --panel-border-outer: 0 0 0 var(--panel-border-outer-width) var(--color-gray-dark);
 
@@ -201,6 +206,9 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     display: inline-flex;
     align-items: center;
     gap: var(--space-1);
+    border: none;
+    appearance: none;
+    -webkit-appearance: none;
     background-color: var(--color-panel);
     box-shadow: var(--bevel-button);
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import MainLayout from '../layouts/MainLayout.astro';
-import ItemIcon from '../components/ItemIcon.astro';
+import ItemCard from '../components/ItemCard.astro';
 import { withBase } from '../utils/with-base';
 import { recipeSubtitle } from '../utils/recipe-subtitle';
 import meta from '../data/generated/meta.json';
@@ -157,15 +157,13 @@ const totalRecipes = recipeEntries.length;
                 data-search={entry.name.toLowerCase()}
                 data-category={section.category}
               >
-                <a href={withBase(`/recipe/${entry.id}/`)} class="catalog__link link-chip">
-                  <span class="catalog__icon">
-                    <ItemIcon item={entry.item} />
-                  </span>
-                  <span class="catalog__text">
-                    <span class="catalog__name">{entry.name}</span>
-                    {entry.subtitle && <span class="catalog__item-subtitle">{entry.subtitle}</span>}
-                  </span>
-                </a>
+                <ItemCard
+                  href={withBase(`/recipe/${entry.id}/`)}
+                  item={entry.item}
+                  name={entry.name}
+                  subtitle={entry.subtitle}
+                  class="catalog__link"
+                />
               </li>
             ))}
           </ul>
@@ -358,45 +356,14 @@ const totalRecipes = recipeEntries.length;
     contain-intrinsic-size: auto 4.5rem;
   }
 
-  .catalog__link {
+  /* ItemCard renders its own <a> inside its own scoped style boundary, so a
+     plain selector here would never match it -- :global() escapes that
+     scoping to size/pad the card from the page that lays out its grid. */
+  :global(.catalog__link) {
     width: 100%;
     height: 100%;
     min-height: 3.5rem;
     padding: var(--space-3) var(--space-4);
     gap: var(--space-2);
-    color: var(--color-panel-fg);
-  }
-
-  .catalog__link:focus-visible {
-    outline: 2px solid var(--color-fg);
-    outline-offset: 2px;
-  }
-
-  .catalog__icon {
-    display: block;
-    width: 2rem;
-    flex-shrink: 0;
-    image-rendering: pixelated;
-  }
-
-  .catalog__text {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    gap: 0.125rem;
-  }
-
-  .catalog__name {
-    font-size: 0.875rem;
-    text-wrap: balance;
-  }
-
-  .catalog__item-subtitle {
-    font-size: 0.75rem;
-    color: var(--color-muted);
-    text-transform: capitalize;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 </style>

--- a/src/pages/recipe/[id].astro
+++ b/src/pages/recipe/[id].astro
@@ -4,6 +4,7 @@ import MainLayout from '../../layouts/MainLayout.astro';
 import Badge from '../../components/Badge.astro';
 import CraftingGrid from '../../components/CraftingGrid.astro';
 import IngredientOptions from '../../components/IngredientOptions.astro';
+import ItemCard from '../../components/ItemCard.astro';
 import ItemIcon from '../../components/ItemIcon.astro';
 import ItemStat from '../../components/ItemStat.astro';
 import { buildShapedGrid, buildShapelessGrid, type GridCell } from '../../utils/crafting-grid';
@@ -17,8 +18,10 @@ interface PageProps {
   itemsMap: Map<string, ItemData>;
   prevId: string;
   prevName: string;
+  prevItem: ItemData | null;
   nextId: string;
   nextName: string;
+  nextItem: ItemData | null;
 }
 
 export async function getStaticPaths() {
@@ -29,7 +32,7 @@ export async function getStaticPaths() {
   const withNames = recipeEntries.map((entry) => {
     const resultItem = entry.data.result ? itemsMap.get(entry.data.result.id) : undefined;
     const displayName = resultItem?.name ?? entry.data.id.replace(/_/g, ' ');
-    return { entry, displayName };
+    return { entry, displayName, item: resultItem ?? null };
   });
   withNames.sort((a, b) => a.displayName.localeCompare(b.displayName));
 
@@ -44,14 +47,16 @@ export async function getStaticPaths() {
         itemsMap,
         prevId: prev.entry.id,
         prevName: prev.displayName,
+        prevItem: prev.item,
         nextId: next.entry.id,
         nextName: next.displayName,
+        nextItem: next.item,
       } satisfies PageProps,
     };
   });
 }
 
-const { recipe, displayName, itemsMap, prevId, prevName, nextId, nextName } =
+const { recipe, displayName, itemsMap, prevId, prevName, prevItem, nextId, nextName, nextItem } =
   Astro.props as PageProps;
 
 const resultItem = recipe.result ? itemsMap.get(recipe.result.id) : undefined;
@@ -185,19 +190,23 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
       )
     }
 
-    <div class="recipe__pager">
-      <nav class="recipe__pager-nav">
-        <a href={withBase(`/recipe/${prevId}/`)} class="recipe__pager-link link-chip">
-          <span aria-hidden="true">&larr;</span>
-          <span class="recipe__pager-name">{prevName}</span>
-        </a>
-        <a href={withBase(`/recipe/${nextId}/`)} class="recipe__pager-link link-chip">
-          <span class="recipe__pager-name">{nextName}</span>
-          <span aria-hidden="true">&rarr;</span>
-        </a>
-      </nav>
+    <nav class="recipe__pager" aria-label="Recipe navigation">
+      <ItemCard
+        href={withBase(`/recipe/${prevId}/`)}
+        item={prevItem}
+        name={prevName}
+        subtitle="Previous"
+        class="recipe__pager-link recipe__pager-link--prev"
+      />
       <a href={withBase('/')} class="recipe__pager-home link-chip">All recipes</a>
-    </div>
+      <ItemCard
+        href={withBase(`/recipe/${nextId}/`)}
+        item={nextItem}
+        name={nextName}
+        subtitle="Next"
+        class="recipe__pager-link recipe__pager-link--next"
+      />
+    </nav>
   </div>
 </MainLayout>
 
@@ -302,10 +311,17 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     color: var(--color-panel-fg);
   }
 
+  /* Mobile: prev/next share a row, "All recipes" sits centered below on its
+     own row. Desktop (see media query): all three on one row, "All recipes"
+     centered between prev and next. A fixed grid-template-areas switch, not
+     flex-wrap, so this never depends on guessing what fits at a given width. */
   .recipe__pager {
     margin-top: var(--space-12);
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      'prev next'
+      'home home';
     align-items: center;
     gap: var(--space-4);
     border-top: 1px solid var(--color-border);
@@ -313,30 +329,38 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     font-size: 0.875rem;
   }
 
-  .recipe__pager-nav {
-    display: flex;
-    justify-content: space-between;
-    gap: var(--space-4);
-    width: 100%;
+  /* ItemCard renders its own <a> inside its own scoped style boundary, so a
+     plain selector here would never match it -- :global() escapes that
+     scoping to size/pad/place the card from the page that lays out the
+     pager grid. */
+  :global(.recipe__pager-link) {
+    min-width: 0;
+    max-width: 14rem;
+    padding: var(--space-3) var(--space-4);
+    gap: var(--space-2);
   }
 
-  .recipe__pager-link {
-    min-width: 0;
-    max-width: 48%;
-    padding: var(--space-2) var(--space-4);
-    color: var(--color-panel-fg);
+  :global(.recipe__pager-link--prev) {
+    grid-area: prev;
+    justify-self: start;
   }
 
-  .recipe__pager-name {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    text-transform: capitalize;
+  :global(.recipe__pager-link--next) {
+    grid-area: next;
+    justify-self: end;
   }
 
   .recipe__pager-home {
+    grid-area: home;
+    justify-self: center;
     padding: var(--space-2) var(--space-4);
     color: var(--color-panel-fg);
+  }
+
+  @media (min-width: 640px) {
+    .recipe__pager {
+      grid-template-columns: 1fr auto 1fr;
+      grid-template-areas: 'prev home next';
+    }
   }
 </style>

--- a/src/pages/recipe/[id].astro
+++ b/src/pages/recipe/[id].astro
@@ -16,7 +16,9 @@ interface PageProps {
   displayName: string;
   itemsMap: Map<string, ItemData>;
   prevId: string;
+  prevName: string;
   nextId: string;
+  nextName: string;
 }
 
 export async function getStaticPaths() {
@@ -41,13 +43,16 @@ export async function getStaticPaths() {
         displayName,
         itemsMap,
         prevId: prev.entry.id,
+        prevName: prev.displayName,
         nextId: next.entry.id,
+        nextName: next.displayName,
       } satisfies PageProps,
     };
   });
 }
 
-const { recipe, displayName, itemsMap, prevId, nextId } = Astro.props as PageProps;
+const { recipe, displayName, itemsMap, prevId, prevName, nextId, nextName } =
+  Astro.props as PageProps;
 
 const resultItem = recipe.result ? itemsMap.get(recipe.result.id) : undefined;
 const getItemName = (id: string) => itemsMap.get(id)?.name ?? id;
@@ -97,31 +102,29 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
   description={`How to craft ${displayName} in Minecraft.`}
 >
   <div class="recipe">
-    <nav class="recipe__breadcrumb">
-      <a href={withBase('/')}>&larr; All recipes</a>
-    </nav>
+    <div class="recipe__toolbar">
+      <a href={withBase('/')} class="recipe__back link-chip">&larr; Back to all recipes</a>
+      <button type="button" class="recipe__copy-link link-chip" data-url={canonicalUrl} hidden>
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+        </svg>
+        <span class="recipe__copy-link-label">Copy link</span>
+      </button>
+    </div>
 
     <div class="recipe__header">
-      <div class="recipe__title-row">
-        <h1 class="recipe__title">{displayName}</h1>
-        <button type="button" class="recipe__copy-link link-chip" data-url={canonicalUrl} hidden>
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
-            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
-          </svg>
-          <span class="recipe__copy-link-label">Copy link</span>
-        </button>
-      </div>
+      <h1 class="recipe__title">{displayName}</h1>
       <div class="recipe__badges">
         {
           isShapeless && (
@@ -182,13 +185,19 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
       )
     }
 
-    <nav class="recipe__pager">
-      <a href={withBase(`/recipe/${prevId}/`)} class="recipe__pager-link link-chip"
-        >&larr; Previous</a
-      >
-      <a href={withBase('/')} class="recipe__pager-link recipe__pager-link--home">All recipes</a>
-      <a href={withBase(`/recipe/${nextId}/`)} class="recipe__pager-link link-chip">Next &rarr;</a>
-    </nav>
+    <div class="recipe__pager">
+      <nav class="recipe__pager-nav">
+        <a href={withBase(`/recipe/${prevId}/`)} class="recipe__pager-link link-chip">
+          <span aria-hidden="true">&larr;</span>
+          <span class="recipe__pager-name">{prevName}</span>
+        </a>
+        <a href={withBase(`/recipe/${nextId}/`)} class="recipe__pager-link link-chip">
+          <span class="recipe__pager-name">{nextName}</span>
+          <span aria-hidden="true">&rarr;</span>
+        </a>
+      </nav>
+      <a href={withBase('/')} class="recipe__pager-home link-chip">All recipes</a>
+    </div>
   </div>
 </MainLayout>
 
@@ -225,16 +234,19 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 </script>
 
 <style>
-  .recipe__breadcrumb {
-    margin-bottom: var(--space-6);
-    font-size: 0.875rem;
-  }
-
-  .recipe__title-row {
+  .recipe__toolbar {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
     gap: var(--space-3);
+    margin-bottom: var(--space-6);
+    font-size: 0.8125rem;
+  }
+
+  .recipe__back {
+    padding: var(--space-2) var(--space-4);
+    color: var(--color-panel-fg);
   }
 
   .recipe__copy-link {
@@ -276,11 +288,8 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     align-items: center;
     gap: var(--space-4);
     background-color: var(--color-panel);
-    padding: var(--space-4);
-    border: var(--panel-border-width) solid;
-    border-color: var(--panel-border-color);
-    border-radius: var(--radius-md);
-    box-shadow: var(--panel-border-outer);
+    padding: calc(var(--space-4) + var(--panel-border-width));
+    box-shadow: var(--bevel-panel), var(--panel-border-outer);
   }
 
   .recipe__special-icon {
@@ -296,19 +305,38 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
   .recipe__pager {
     margin-top: var(--space-12);
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
+    align-items: center;
     gap: var(--space-4);
     border-top: 1px solid var(--color-border);
     padding-top: var(--space-4);
     font-size: 0.875rem;
   }
 
+  .recipe__pager-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-4);
+    width: 100%;
+  }
+
   .recipe__pager-link {
+    min-width: 0;
+    max-width: 48%;
     padding: var(--space-2) var(--space-4);
     color: var(--color-panel-fg);
   }
 
-  .recipe__pager-link--home {
-    color: var(--color-muted);
+  .recipe__pager-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-transform: capitalize;
+  }
+
+  .recipe__pager-home {
+    padding: var(--space-2) var(--space-4);
+    color: var(--color-panel-fg);
   }
 </style>


### PR DESCRIPTION
- .link-chip now resets native button border/appearance, so the filter
  toggle and copy-link buttons no longer show a stray white UA border,
  and anchor-based link-chips (pager, catalog cards, category pills) no
  longer pick up the global <a> underline on hover/press.
- Large panels (crafting grid, ingredient options, special recipe box)
  now use a new --bevel-panel box-shadow, the same stepped-pixel bevel
  technique as buttons/slots, instead of a mitered four-color CSS border.
- Crafting grid's arrow + result are now grouped so they wrap together
  as one unit on narrow viewports instead of the result cell splitting
  off alone onto its own line.
- Recipe detail page: "All recipes" link is now a proper button labeled
  "Back to all recipes", on the same row as (and left-aligned against)
  the Copy link button. The bottom pager now shows the actual prev/next
  item names and renders "All recipes" as a button below the Previous/
  Next row.