### PR TITLE
Polish crafting UI: two-tone dividers, ingredient label wording, icon bug fixes

### DIFF
--- a/src/components/IngredientOptions.astro
+++ b/src/components/IngredientOptions.astro
@@ -76,7 +76,6 @@ const { entries, itemsMap, note } = Astro.props;
     width: 2.25rem;
     height: 2.25rem;
     padding: var(--space-2);
-    font-size: 0.7em;
     background-color: var(--color-slot);
     box-shadow: var(--bevel-slot);
   }

--- a/src/components/IngredientOptions.astro
+++ b/src/components/IngredientOptions.astro
@@ -75,7 +75,7 @@ const { entries, itemsMap, note } = Astro.props;
     flex-shrink: 0;
     width: 2.25rem;
     height: 2.25rem;
-    padding: var(--space-1);
+    padding: var(--space-2);
     font-size: 0.7em;
     background-color: var(--color-slot);
     box-shadow: var(--bevel-slot);

--- a/src/components/ItemCard.astro
+++ b/src/components/ItemCard.astro
@@ -6,13 +6,18 @@ interface Props {
   href: string;
   item: ItemData | null;
   name: string;
-  /** Small caption under the name -- e.g. a disambiguating recipe subtitle
-      on the catalog, or "Previous"/"Next" on the recipe pager. */
+  /** Small caption -- e.g. a disambiguating recipe subtitle on the catalog,
+      or "Previous"/"Next" on the recipe pager. */
   subtitle?: string | null;
+  /** Render the subtitle above the name instead of below -- the pager's
+      "Previous"/"Next" is a nav label, not a caption describing the item, so
+      it reads better as an eyebrow above the (larger) name for weight
+      distribution. Catalog cards keep the default (subtitle below). */
+  subtitleFirst?: boolean;
   class?: string;
 }
 
-const { href, item, name, subtitle, class: className } = Astro.props;
+const { href, item, name, subtitle, subtitleFirst = false, class: className } = Astro.props;
 ---
 
 <a href={href} class:list={['item-card', 'link-chip', className]}>
@@ -20,8 +25,9 @@ const { href, item, name, subtitle, class: className } = Astro.props;
     <ItemIcon item={item} />
   </span>
   <span class="item-card__text">
+    {subtitleFirst && subtitle && <span class="item-card__subtitle">{subtitle}</span>}
     <span class="item-card__name">{name}</span>
-    {subtitle && <span class="item-card__subtitle">{subtitle}</span>}
+    {!subtitleFirst && subtitle && <span class="item-card__subtitle">{subtitle}</span>}
   </span>
 </a>
 

--- a/src/components/ItemIcon.astro
+++ b/src/components/ItemIcon.astro
@@ -84,7 +84,6 @@ const isBlock = item?.icon.type === 'block';
   .icon {
     width: 100%;
     height: auto;
-    background-color: var(--color-slot);
   }
 
   .block {

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -15,7 +15,8 @@ import meta from '../data/generated/meta.json';
 <style>
   footer {
     margin-top: auto;
-    border-top: 1px solid var(--color-border);
+    border-top: var(--divider-border);
+    box-shadow: var(--divider-shadow-top);
   }
 
   .footer__text {

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -29,7 +29,8 @@ const isActive = (path: string) => {
 
 <style>
   header {
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: var(--divider-border);
+    box-shadow: var(--divider-shadow-bottom);
   }
 
   .header-content {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -67,39 +67,50 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     --color-panel-fg: var(--color-gray-dark);
     --color-slot: var(--color-gray);
 
+    /* Single source of truth for the "chunky pixel border" thickness used by
+       every bevel below -- slots, buttons, and large panels all read this one
+       variable, so dialing it in one place moves the whole site in lockstep.
+       Kept in rem, not em, so it can no longer be silently shrunk by an
+       element setting its own font-size (the previous em-based bevels were,
+       which is why the ingredient-options slot's border used to look
+       thinner than the crafting grid's). */
+    --bevel-width: 0.5rem;
+
     /* The Minecraft inset/outset bevel: a background color plus two
        translucent box-shadows -- one dark, one light -- offset diagonally so
        each shows up as a solid pip of color in opposite corners. --bevel-slot
        is the recessed look for crafting/ingredient item slots; --bevel-button
        is the exact same colors and offset with the corners flipped, for a
-       raised/clickable look. Both stay off border-radius -- the alpha shadow
-       clipped by a curved corner reads as a smudgy gradient, not a clean
-       stamped edge. */
+       raised/clickable look; --bevel-button-pressed matches --bevel-slot's
+       direction (a pressed button looks recessed, like a slot); --bevel-panel
+       is the same raised direction as --bevel-button, for large panels
+       (crafting grid, ingredient options, special recipe box). All four stay
+       off border-radius -- the alpha shadow clipped by a curved corner reads
+       as a smudgy gradient, not a clean stamped edge. */
     --bevel-slot:
-      0.5em 0.5em 0 0 rgba(0, 0, 0, 0.5) inset, -0.5em -0.5em 0 0 rgba(255, 255, 255, 0.75) inset;
+      var(--bevel-width) var(--bevel-width) 0 0 rgba(0, 0, 0, 0.5) inset,
+      calc(-1 * var(--bevel-width)) calc(-1 * var(--bevel-width)) 0 0 rgba(255, 255, 255, 0.75)
+        inset;
     --bevel-button:
-      -0.5em -0.5em 0 0 rgba(0, 0, 0, 0.5) inset, 0.5em 0.5em 0 0 rgba(255, 255, 255, 0.75) inset;
+      calc(-1 * var(--bevel-width)) calc(-1 * var(--bevel-width)) 0 0 rgba(0, 0, 0, 0.5) inset,
+      var(--bevel-width) var(--bevel-width) 0 0 rgba(255, 255, 255, 0.75) inset;
     --bevel-button-pressed:
-      0.5em 0.5em 0 0 rgba(0, 0, 0, 0.5) inset, -0.5em -0.5em 0 0 rgba(255, 255, 255, 0.75) inset;
-    /* Larger panels (crafting grid, ingredient options, special recipe box):
-       drawn with --bevel-panel (below) at this thickness -- panels pad
-       their content by this amount extra so the bevel has room to sit
-       inside the padding box -- plus a thin darker-gray ring just outside.
-       --bevel-panel derives its offsets from this same variable so the two
-       never drift out of sync. */
-    --panel-border-width: 0.5rem;
+      var(--bevel-width) var(--bevel-width) 0 0 rgba(0, 0, 0, 0.5) inset,
+      calc(-1 * var(--bevel-width)) calc(-1 * var(--bevel-width)) 0 0 rgba(255, 255, 255, 0.75)
+        inset;
+    --bevel-panel:
+      calc(-1 * var(--bevel-width)) calc(-1 * var(--bevel-width)) 0 0 rgba(0, 0, 0, 0.5) inset,
+      var(--bevel-width) var(--bevel-width) 0 0 rgba(255, 255, 255, 0.75) inset;
+
+    /* Larger panels (crafting grid, ingredient options, special recipe box)
+       pad their content by --bevel-width extra so --bevel-panel has room to
+       sit inside the padding box -- plus a thin darker-gray ring just
+       outside. --panel-border-width is just --bevel-width under the name
+       panel padding math reaches for; keeping it as an alias (not a second
+       literal) is what keeps it in lockstep with every other bevel above. */
+    --panel-border-width: var(--bevel-width);
     --panel-border-outer-width: 0.125rem;
     --panel-border-outer: 0 0 0 var(--panel-border-outer-width) var(--color-gray-dark);
-
-    /* Same raised-bevel direction as --bevel-button, but in fixed rem units
-       (not em) and offset by --panel-border-width -- used by large panels
-       (crafting grid, ingredient options, special recipe box) so their
-       "border" is the same stepped-pixel block as the small button/slot
-       bevels, not a mitered border-color trick. */
-    --bevel-panel:
-      calc(-1 * var(--panel-border-width)) calc(-1 * var(--panel-border-width)) 0 0
-        rgba(0, 0, 0, 0.5) inset,
-      var(--panel-border-width) var(--panel-border-width) 0 0 rgba(255, 255, 255, 0.75) inset;
 
     /* Shape */
     --radius-sm: 0.125rem;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -127,8 +127,8 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
        border-bottom; the highlight shadow direction has to match which edge
        the border is drawn on, hence the two variants. */
     --divider-border: 0.0625rem solid var(--color-gray-dark);
-    --divider-shadow-top: inset 0 -0.0625rem 0 0 rgba(255, 255, 255, 0.75);
-    --divider-shadow-bottom: inset 0 0.0625rem 0 0 rgba(255, 255, 255, 0.75);
+    --divider-shadow-top: inset 0 0.0625rem 0 0 rgba(255, 255, 255, 0.75);
+    --divider-shadow-bottom: inset 0 -0.0625rem 0 0 rgba(255, 255, 255, 0.75);
 
     /* Spacing */
     --space-1: 0.25rem;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -74,7 +74,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
        element setting its own font-size (the previous em-based bevels were,
        which is why the ingredient-options slot's border used to look
        thinner than the crafting grid's). */
-    --bevel-width: 0.5rem;
+    --bevel-width: 0.3125rem;
 
     /* The Minecraft inset/outset bevel: a background color plus two
        translucent box-shadows -- one dark, one light -- offset diagonally so

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -81,14 +81,25 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
       -0.5em -0.5em 0 0 rgba(0, 0, 0, 0.5) inset, 0.5em 0.5em 0 0 rgba(255, 255, 255, 0.75) inset;
     --bevel-button-pressed:
       0.5em 0.5em 0 0 rgba(0, 0, 0, 0.5) inset, -0.5em -0.5em 0 0 rgba(255, 255, 255, 0.75) inset;
+    /* Larger panels (crafting grid, ingredient options, special recipe box):
+       drawn with --bevel-panel (below) at this thickness -- panels pad
+       their content by this amount extra so the bevel has room to sit
+       inside the padding box -- plus a thin darker-gray ring just outside.
+       --bevel-panel derives its offsets from this same variable so the two
+       never drift out of sync. */
+    --panel-border-width: 0.5rem;
+    --panel-border-outer-width: 0.125rem;
+    --panel-border-outer: 0 0 0 var(--panel-border-outer-width) var(--color-gray-dark);
+
     /* Same raised-bevel direction as --bevel-button, but in fixed rem units
        (not em) and offset by --panel-border-width -- used by large panels
        (crafting grid, ingredient options, special recipe box) so their
        "border" is the same stepped-pixel block as the small button/slot
        bevels, not a mitered border-color trick. */
     --bevel-panel:
-      -0.5rem -0.5rem 0 0 rgba(0, 0, 0, 0.5) inset,
-      0.5rem 0.5rem 0 0 rgba(255, 255, 255, 0.75) inset;
+      calc(-1 * var(--panel-border-width)) calc(-1 * var(--panel-border-width)) 0 0
+        rgba(0, 0, 0, 0.5) inset,
+      var(--panel-border-width) var(--panel-border-width) 0 0 rgba(255, 255, 255, 0.75) inset;
 
     /* Shape */
     --radius-sm: 0.125rem;
@@ -97,13 +108,16 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
     /* Flat, solid "chunky" border -- the search input uses this alone. */
     --border-width: 0.125rem;
 
-    /* Larger panels (crafting grid, ingredient options, special recipe box):
-       drawn with --bevel-panel (see above) at this thickness -- panels pad
-       their content by this amount extra so the bevel has room to sit
-       inside the padding box -- plus a thin darker-gray ring just outside. */
-    --panel-border-width: 0.5rem;
-    --panel-border-outer-width: 0.125rem;
-    --panel-border-outer: 0 0 0 var(--panel-border-outer-width) var(--color-gray-dark);
+    /* Two-tone horizontal divider (site header, footer, recipe pager) -- a
+       dark line plus an inset highlight right next to it, same dark/light
+       pairing as the bevels above, instead of the flat single-tone
+       --color-border rule that reads as out of place next to all the
+       stepped-pixel bevel UI. --divider-border works on either border-top or
+       border-bottom; the highlight shadow direction has to match which edge
+       the border is drawn on, hence the two variants. */
+    --divider-border: 0.0625rem solid var(--color-gray-dark);
+    --divider-shadow-top: inset 0 -0.0625rem 0 0 rgba(255, 255, 255, 0.75);
+    --divider-shadow-bottom: inset 0 0.0625rem 0 0 rgba(255, 255, 255, 0.75);
 
     /* Spacing */
     --space-1: 0.25rem;

--- a/src/pages/recipe/[id].astro
+++ b/src/pages/recipe/[id].astro
@@ -196,6 +196,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
         item={prevItem}
         name={prevName}
         subtitle="Previous"
+        subtitleFirst
         class="recipe__pager-link recipe__pager-link--prev"
       />
       <a href={withBase('/')} class="recipe__pager-home link-chip">All recipes</a>
@@ -204,6 +205,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
         item={nextItem}
         name={nextName}
         subtitle="Next"
+        subtitleFirst
         class="recipe__pager-link recipe__pager-link--next"
       />
     </nav>
@@ -324,7 +326,8 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
       'home home';
     align-items: center;
     gap: var(--space-4);
-    border-top: 1px solid var(--color-border);
+    border-top: var(--divider-border);
+    box-shadow: var(--divider-shadow-top);
     padding-top: var(--space-4);
     font-size: 0.875rem;
   }

--- a/src/utils/tag-label.ts
+++ b/src/utils/tag-label.ts
@@ -1,15 +1,22 @@
 import type { Ingredient } from "../content.config";
 
 /**
+ * Title-cases a snake_case tag name, e.g. `oak_logs` -> "Oak Logs".
+ */
+function tagWords(tag: string): string {
+  return tag
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
  * Humanizes a resolved tag name into a recipe-book-style label, e.g.
  * `oak_logs` -> "Any Oak Logs", `planks` -> "Any Planks".
  */
 export function humanizeTagLabel(tag: string): string {
-  const words = tag
-    .split("_")
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1));
-  return `Any ${words.join(" ")}`;
+  return `Any ${tagWords(tag)}`;
 }
 
 export interface IngredientOption {
@@ -22,7 +29,10 @@ export interface IngredientOption {
  * Builds the label + variant items shown for a multi-option ingredient.
  * Returns `null` for single-item ingredients (nothing to show).
  *
- * - Tag-based (e.g. "planks"): humanized tag, "Any Planks".
+ * - Tag-based (e.g. "planks"): title-cased tag, "Planks" -- no "Any" prefix
+ *   here, since this label is always shown nested under an "Accepts any of
+ *   these" heading and repeating "any" reads as if the ingredient can go
+ *   anywhere in the grid rather than accept any of these item variants.
  * - Non-tag multi-option: first item's name (the cycling icon + option
  *   count carry the "or others" information, so the label doesn't need to).
  */
@@ -34,9 +44,7 @@ export function ingredientOption(
     return null;
   }
 
-  const label = ingredient.tag
-    ? humanizeTagLabel(ingredient.tag)
-    : getItemName(ingredient.items[0]);
+  const label = ingredient.tag ? tagWords(ingredient.tag) : getItemName(ingredient.items[0]);
 
   return { label, items: ingredient.items };
 }

--- a/tests/tag-label.test.ts
+++ b/tests/tag-label.test.ts
@@ -22,10 +22,10 @@ describe("ingredientOption", () => {
     expect(ingredientOption({ items: ["stick"] }, itemName)).toBeNull();
   });
 
-  it("labels a tag-based multi-option ingredient with the humanized tag", () => {
+  it("labels a tag-based multi-option ingredient with the title-cased tag, no 'Any' prefix", () => {
     const ingredient = { items: ["oak_planks", "spruce_planks"], tag: "planks" };
     expect(ingredientOption(ingredient, itemName)).toEqual({
-      label: "Any Planks",
+      label: "Planks",
       items: ["oak_planks", "spruce_planks"],
     });
   });


### PR DESCRIPTION
- Replace the flat single-tone divider (header, footer, recipe pager) with a
  two-tone dark+highlight rule matching the site's bevel language, sharing new
  --divider-border/--divider-shadow-top/--divider-shadow-bottom tokens.
- Tie --bevel-panel's offsets to --panel-border-width instead of a second
  hardcoded value, so the two can no longer drift out of sync.
- Drop the redundant "Any" from ingredient-options tag labels ("Any Acacia
  Logs" -> "Acacia Logs") since it's already nested under an "Accepts any of
  these" heading and read as if the ingredient could go anywhere in the grid.
- Give the ingredient-options icon slot more breathing room.
- Remove a hardcoded background-color from ItemIcon's flat <img> that leaked
  through transparent icons (e.g. the hanging sign) as a mismatched gray
  square on item cards, which sit on a lighter panel background than crafting
  slots do.
- Add ItemCard subtitleFirst so the recipe pager's "Previous"/"Next" reads as
  a label above the item name instead of a caption below it.