### PR TITLE
Bump GitHub Actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,9 @@ jobs:
       BASE_PATH: ${{ vars.BASE_PATH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Astro
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
actions/checkout@v4, actions/setup-node@v4, actions/upload-pages-artifact@v3, and actions/deploy-pages@v4 all declare the deprecated Node 20 runtime in their action.yml, so every deploy run was getting forced onto Node 24 with a warning instead of running natively.

Bumps each to the latest major that declares `node24` natively, confirmed via each action's action.yml: checkout to v7, setup-node to v6, upload-pages-artifact to v5, deploy-pages to v5. No inputs or job structure changed.