### PR TITLE
Add CI workflow to validate PRs before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+      - name: Install dependencies from lockfile
+        run: npm ci
+      - name: Check formatting
+        run: npm run format:check
+      - name: Type check
+        run: npm run type-check
+      - name: Lint
+        run: npm run lint
+      - name: Unit tests
+        run: npm test
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Craftalog has no PR gating today — `deploy.yml` only runs on push to `main`
- Adds `.github/workflows/ci.yml`, mirroring the `verify` skill's format/type-check/lint/test/build sequence
- This PR is the check-name registration run: once green, `main`'s branch protection will be reconfigured to require the `ci` status check (dropping the review requirement) and native auto-merge will be enabled

## Test plan
- [x] Verified all five steps pass locally in a clean clone of this branch (format:check, type-check, lint, test, build)
- [ ] Confirm the `ci` workflow run shows green on this PR