### PR TITLE
Remove CI verification throwaway file

### DIFF
--- a/.github/CI_VERIFY.md
+++ b/.github/CI_VERIFY.md
@@ -1,1 +1,0 @@
-Throwaway file to verify the CI + native auto-merge pipeline end-to-end. Safe to delete.


### PR DESCRIPTION
Cleans up the throwaway file added to verify the CI + auto-merge pipeline in #35.