### PR TITLE
Add merge_group trigger to CI for upcoming merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Prep step for enabling GitHub's native merge queue on `main`
- Adds a `merge_group:` trigger to `ci.yml` — GitHub Actions requires this on any workflow that provides a required status check once a branch requires a merge queue, otherwise the check never runs against the queue's temporary merge ref and queued PRs stall until timeout
- Once this merges, a repo-level ruleset requiring the merge queue on `main` will be added

## Test plan
- [ ] `ci` passes on this PR (`pull_request` trigger unaffected by the change)