### PR TITLE
fix: compound icon camera showed south+east instead of vanilla's north+east

### DIFF
--- a/scripts/lib/generate.ts
+++ b/scripts/lib/generate.ts
@@ -94,8 +94,8 @@ interface ResolvedCompoundElement {
  * unresolved" contract every other icon type here already follows. All 6
  * cardinal faces are resolved (whichever the candidate's own element data
  * actually declares) -- see scripts/lib/model.ts's extractCompoundElements
- * and ItemIcon.astro's computeFaceStyle for why down/north/west matter
- * alongside up/east/south. No culling pass: an earlier version of this
+ * and ItemIcon.astro's computeFaceStyle for why down/south/west matter
+ * alongside up/north/east. No culling pass: an earlier version of this
  * function dropped faces on any partial footprint overlap between two
  * elements' touching boundary, on the theory that coplanar contact seams
  * cause CSS z-fighting -- that diagnosis was wrong (confirmed: rendering

--- a/scripts/lib/model.ts
+++ b/scripts/lib/model.ts
@@ -411,10 +411,13 @@ function defaultFaceUv(
  * element geometry, for block models classifyChain doesn't recognize as any
  * named shape (e.g. anvil, whose 4-element template_anvil parent has no
  * dedicated classifyChain branch). All 6 declared faces are kept per
- * element -- up/east/south are the only 3 a SIMPLE CONVEX box ever shows
- * from this catalog's fixed isometric camera, but concave/hollow/stepped
- * shapes (e.g. composter's open-top hollow box, grindstone's post-and-wheel
- * assembly) genuinely expose down/north/west-facing surfaces too (see
+ * element -- up/north/east are the only 3 a SIMPLE CONVEX box ever shows
+ * from the compound camera (rotateX(-35deg) rotateY(-135deg), matching the
+ * face set vanilla's own GUI camera [30, 225, 0] shows: east on
+ * screen-left, north on screen-right -- see ItemIcon.astro's .compound
+ * rule for the evidence), but concave/hollow/stepped shapes (e.g.
+ * composter's open-top hollow box, grindstone's post-and-wheel assembly)
+ * genuinely expose down/south/west-facing surfaces too (see
  * ItemIcon.astro's computeFaceStyle, which renders whichever of the 6 a
  * given element actually has). Each kept face also carries its `uv` crop
  * rect (explicit from the model JSON, or defaultFaceUv's fallback) --
@@ -456,49 +459,7 @@ function extractCompoundElements(
   }
   if (elements.length === 0) return undefined;
 
-  swapFullCubeFrontFaces(elements);
-
   return { elements, yRotation: findGuiYawDelta(chainNames, models) };
-}
-
-/**
- * Shows a full-cube block's "front" texture on the camera-visible face.
- *
- * The catalog's fixed isometric camera (rotateX(-35deg) rotateY(-45deg) --
- * see ItemIcon.astro) shows a box's UP, SOUTH, and EAST faces; vanilla's own
- * default GUI camera (rotation [30, 225, 0], from block/block.json) shows
- * UP, NORTH, and EAST -- the horizontal mirror. Vanilla's convention puts a
- * block's distinguishing "front" texture on NORTH (furnace, crafting table,
- * observer, crafter, chiseled bookshelf), so rendered as-is here such a
- * block shows its back/side where the vanilla icon shows its front. The
- * shipped "block" icon type already corrects for this by resolving
- * side=*_front (furnace/crafting_table/loom); this is the compound
- * equivalent: swap the north/south face data so the front lands on the
- * visible south slot. The verbatim swap is exact for a full cube -- the
- * renderer maps south's u axis along +x from screen-left while vanilla maps
- * north's u axis along -x from screen-left, so the moved texture reads
- * unmirrored, exactly like the vanilla icon (the now-hidden north face
- * carries the back texture, invisibly).
- *
- * Restricted to single-element full-cube models with BOTH faces declared:
- * multi-element/partial-box geometry would repaint physically distinct
- * surfaces (and every such shape verified against this camera -- anvil,
- * grindstone, composter -- is north/south-symmetric anyway), and a cube
- * declaring only one of the pair (a context-culled in-world model) would
- * lose its declared face to the hidden slot instead of gaining a front.
- */
-function swapFullCubeFrontFaces(elements: CompoundElementCandidate[]): void {
-  if (elements.length !== 1) return;
-  const [el] = elements;
-  const isFullCube =
-    el.from[0] === 0 &&
-    el.from[1] === 0 &&
-    el.from[2] === 0 &&
-    el.to[0] === 16 &&
-    el.to[1] === 16 &&
-    el.to[2] === 16;
-  if (!isFullCube || !el.faces.north || !el.faces.south) return;
-  [el.faces.north, el.faces.south] = [el.faces.south, el.faces.north];
 }
 
 /**

--- a/scripts/lib/types.ts
+++ b/scripts/lib/types.ts
@@ -93,11 +93,11 @@ export interface RawModelElementFace {
  * One element (a single axis-aligned box) of a block model's `elements`
  * array, in 0-16 block-space coordinates. `faces` is keyed by all 6
  * cardinal directions, and extractCompoundElements (scripts/lib/model.ts)
- * reads all 6 -- up/east/south are the only 3 a SIMPLE CONVEX box ever
- * shows from this catalog's fixed isometric camera (see ItemIcon.astro's
- * shared `rotateX(-35deg) rotateY(-45deg)` camera), but concave/hollow/
- * stepped shapes (e.g. composter, grindstone) genuinely expose down/north/
- * west-facing surfaces too.
+ * reads all 6 -- up/north/east are the only 3 a SIMPLE CONVEX box ever
+ * shows from the compound camera (see ItemIcon.astro's `.compound`
+ * `rotateX(-35deg) rotateY(-135deg)` camera, which matches vanilla's own
+ * GUI face selection), but concave/hollow/stepped shapes (e.g. composter,
+ * grindstone) genuinely expose down/south/west-facing surfaces too.
  */
 export interface RawModelElement {
   from: [number, number, number];

--- a/src/components/ItemIcon.astro
+++ b/src/components/ItemIcon.astro
@@ -62,11 +62,12 @@ interface CompoundFaceStyle {
  * above, pixel-for-pixel, for a full cube, a slab, and a pressure plate)
  * against this exact shared camera.
  *
- * All 6 directions are implemented. up/east/south are the only 3 faces a
- * SIMPLE CONVEX box ever shows from this camera (rotateX(-35deg)
- * rotateY(-45deg)) -- but concave/hollow/stepped shapes (e.g. composter's
+ * All 6 directions are implemented. up/north/east are the only 3 faces a
+ * SIMPLE CONVEX box ever shows from the compound camera (rotateX(-35deg)
+ * rotateY(-135deg), matching vanilla's own GUI face selection -- see the
+ * `.compound` rule below) -- but concave/hollow/stepped shapes (e.g. composter's
  * open-top hollow box, grindstone's post-and-wheel assembly) need
- * down/north/west too, for interior-facing surfaces this same fixed camera
+ * down/south/west too, for interior-facing surfaces this same fixed camera
  * genuinely exposes through a gap in the rest of the geometry. down and west
  * are a naive sign-flip mirror of up/east (opposite rotation direction,
  * anchored at the near-side coordinate instead of the far-side one) --
@@ -86,9 +87,12 @@ interface CompoundFaceStyle {
  * outside the icon -- caught by adding a real, non-cubic element to the
  * validation sweep, not by the cube check alone.
  *
- * Validated three ways: (1) a full solid cube rendered with all 6 faces is
+ * Validated three ways (originally under the pre-fix -45deg yaw; the same
+ * depth-sorting argument holds unchanged at -135deg, re-verified visually
+ * against dried_ghast/anvil/grindstone/composter after the camera fix):
+ * (1) a full solid cube rendered with all 6 faces is
  * pixel-identical (bar sub-pixel edge AA) to one rendered with only
- * up/east/south -- the 3 new faces stay fully hidden behind the visible
+ * the 3 camera-facing faces -- the hidden faces stay fully behind the visible
  * ones for ordinary convex geometry, exactly like a real cube; (2)
  * composter's and grindstone's real element geometry, re-rendered with
  * every face their model JSON declares, closes the visible gaps that
@@ -977,13 +981,27 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
      computeFaceStyle), rather than hand-authored per-shape rules like every
      class above. `--compound-y-rotation` is an optional extra yaw (from the
      model's own display.gui override, relative to vanilla's [30,225,0]
-     default -- see scripts/lib/model.ts) composed on top of the shared
-     camera; 0deg for models that don't override "gui" (e.g. anvil itself). */
+     default -- see scripts/lib/model.ts) composed on top of the camera;
+     0deg for models that don't override "gui" (e.g. anvil itself).
+
+     The yaw is -135deg, NOT the -45deg the simpler `.block` icons use:
+     -135deg shows a box's UP, EAST (screen-left) and NORTH (screen-right)
+     faces -- the exact face placement of vanilla's own GUI camera (rotation
+     [30, 225, 0], block/block.json). Verified three independent ways:
+     (1) rotating the [30,225,0] gui transform's yaw through Minecraft's
+     axis convention (+X east, -Z north) puts north's normal screen-right
+     and east's screen-left; (2) a real in-game inventory screenshot of
+     dried_ghast (whose 4 side textures all differ) shows its east speckle
+     texture on the left face and its north eyes/mouth texture on the
+     right; (3) the wiki's game-rendered furnace invicon shows the furnace
+     mouth (its north "front" face) on the right face. At -45deg the
+     renderer showed SOUTH+EAST instead, so any north/south-asymmetric
+     compound model (dried_ghast's face) hid its front entirely. */
   .compound {
     position: absolute;
     inset: 0;
     transform-style: preserve-3d;
-    transform: rotateX(-35deg) rotateY(-45deg) rotateY(var(--compound-y-rotation, 0deg));
+    transform: rotateX(-35deg) rotateY(-135deg) rotateY(var(--compound-y-rotation, 0deg));
   }
 
   /* Each face is TWO nested elements on purpose: cropping a transformed

--- a/src/data/generated/items.json
+++ b/src/data/generated/items.json
@@ -3677,7 +3677,7 @@
               ]
             },
             "north": {
-              "texture": "/textures/block/chiseled_bookshelf_side.png",
+              "texture": "/textures/block/chiseled_bookshelf_empty.png",
               "uv": [
                 0,
                 0,
@@ -3686,7 +3686,7 @@
               ]
             },
             "south": {
-              "texture": "/textures/block/chiseled_bookshelf_empty.png",
+              "texture": "/textures/block/chiseled_bookshelf_side.png",
               "uv": [
                 0,
                 0,
@@ -4747,7 +4747,7 @@
               ]
             },
             "north": {
-              "texture": "/textures/block/crafter_south.png",
+              "texture": "/textures/block/crafter_north.png",
               "uv": [
                 0,
                 0,
@@ -4756,7 +4756,7 @@
               ]
             },
             "south": {
-              "texture": "/textures/block/crafter_north.png",
+              "texture": "/textures/block/crafter_south.png",
               "uv": [
                 0,
                 0,
@@ -6905,18 +6905,18 @@
             "north": {
               "texture": "/textures/block/dried_kelp_side.png",
               "uv": [
+                0,
+                0,
                 16,
-                0,
-                0,
                 16
               ]
             },
             "south": {
               "texture": "/textures/block/dried_kelp_side.png",
               "uv": [
-                0,
-                0,
                 16,
+                0,
+                0,
                 16
               ]
             },
@@ -12570,7 +12570,7 @@
               ]
             },
             "north": {
-              "texture": "/textures/block/observer_back.png",
+              "texture": "/textures/block/observer_front.png",
               "uv": [
                 0,
                 0,
@@ -12579,7 +12579,7 @@
               ]
             },
             "south": {
-              "texture": "/textures/block/observer_front.png",
+              "texture": "/textures/block/observer_back.png",
               "uv": [
                 0,
                 0,

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -670,11 +670,15 @@ describe("resolveIconCandidate: compound (generic multi-element)", () => {
   });
 });
 
-describe("resolveIconCandidate: compound full-cube front swap", () => {
+describe("resolveIconCandidate: compound faces kept as declared (no front swap)", () => {
   // Vanilla puts a full-cube block's "front" texture on NORTH (observer,
-  // crafter, chiseled bookshelf) — a face this catalog's mirrored camera
-  // never shows. Extraction swaps north/south so the front lands on the
-  // visible south slot (see swapFullCubeFrontFaces).
+  // crafter, chiseled bookshelf) — and the compound camera genuinely shows
+  // NORTH (screen-right), matching vanilla's own GUI camera (see
+  // ItemIcon.astro's .compound rule). An earlier version assumed the camera
+  // mirrored vanilla and swapped north/south face data for full cubes; that
+  // masked the camera bug for cubes while multi-element asymmetric models
+  // (dried_ghast's face) stayed hidden. Faces must now pass through
+  // verbatim for every shape.
   const models: RawModelsData = {
     "block/block": {},
     "block/fronted_cube": {
@@ -698,8 +702,8 @@ describe("resolveIconCandidate: compound full-cube front swap", () => {
         },
       ],
     },
-    // Same face layout on a non-full-cube element — must NOT swap (a bare
-    // face swap on partial geometry repaints physically distinct surfaces).
+    // Same face layout on a non-full-cube element — also passes through
+    // verbatim.
     "block/fronted_slab": {
       parent: "block/block",
       textures: { particle: "block/fs_top", front: "block/fs_front", side: "block/fs_side" },
@@ -721,22 +725,22 @@ describe("resolveIconCandidate: compound full-cube front swap", () => {
     fronted_slab: { model: { type: "minecraft:model", model: "minecraft:block/fronted_slab" } },
   };
 
-  it("swaps north/south face data verbatim (texture + uv) for a single-element full cube", () => {
+  it("keeps a single-element full cube's north/south face data (texture + uv) as declared", () => {
     const candidate = resolveIconCandidate("fronted_cube", itemDefinitions, models);
     expect(candidate).toMatchObject({
       type: "compound",
       elements: [
         {
           faces: {
-            south: { texture: "block/fc_front", uv: [0, 0, 16, 16] },
-            north: { texture: "block/fc_side", uv: [16, 0, 0, 16] },
+            north: { texture: "block/fc_front", uv: [0, 0, 16, 16] },
+            south: { texture: "block/fc_side", uv: [16, 0, 0, 16] },
           },
         },
       ],
     });
   });
 
-  it("leaves non-full-cube elements unswapped", () => {
+  it("keeps non-full-cube elements' faces as declared too", () => {
     const candidate = resolveIconCandidate("fronted_slab", itemDefinitions, models);
     expect(candidate).toMatchObject({
       type: "compound",


### PR DESCRIPTION
## Summary

- The compound-icon camera (\`.compound\` in \`ItemIcon.astro\`) was rendering a box's UP/SOUTH/EAST faces, but vanilla's own GUI camera (rotation \`[30, 225, 0]\`) actually shows UP/NORTH/EAST — a 90° yaw error (\`-45deg\` should have been \`-135deg\`).
- This went unnoticed because every compound icon it had been validated against (anvil, grindstone, composter, observer, crafter, chiseled_bookshelf, dried_kelp_block) is north/south-symmetric or was already patched around it via \`swapFullCubeFrontFaces\` — a workaround that swapped north/south face *data* for full cubes to compensate, rather than fixing the camera itself. \`dried_ghast\`'s asymmetric face (multi-element, not a full cube, so the swap hack didn't apply) was the first icon to expose the real bug.
- Fixed the camera yaw directly and deleted \`swapFullCubeFrontFaces\` (no longer needed — faces now pass through as declared, since north is genuinely the visible face). Regenerated \`items.json\`: exactly the 4 previously-swapped items changed (chiseled_bookshelf, crafter, dried_kelp_block, observer), now showing their correct vanilla-declared north face.

## Test plan

- [x] \`npm run format && npm run type-check && npm run lint && npm test && npm run build\` — all green (184/184 tests, 0 type errors, 1121 pages)
- [x] \`npm run parse && npm run validate\` — regenerated data validated, no drift
- [x] Verified against a real in-game screenshot: dried_ghast's face (eyes + mouth) is now visible, matching vanilla
- [x] Re-screenshotted 8 compound icons after the fix (dried_ghast, anvil, grindstone, observer, chiseled_bookshelf, crafter, dried_kelp_block, composter) — all render correctly, no regressions

https://claude.ai/code/session_013ga8yb2vDELdU9x9zZPDtA