### PR TITLE
fix: contain every 3D icon in its box + copper_grate transparency + golem statue tiers

### DIFF
--- a/scripts/lib/model.ts
+++ b/scripts/lib/model.ts
@@ -24,6 +24,31 @@ const FLAT_TERMINALS = new Set(["item/generated", "item/handheld", "builtin/gene
 // element offsets, reconstructing the rod's actual silhouette.
 const LIGHTNING_ROD_ATLAS_PARENTS = new Set(["block/template_lightning_rod"]);
 
+// copper_golem_statue is a `minecraft:special` entity-rendered item with no
+// vendored shape geometry at all -- its item/template_copper_golem_statue.json
+// `base` model only carries a tier-agnostic `particle: block/copper_block`,
+// so every one of the 8 tier/waxed variants resolved to that same flat
+// copper_block swatch (wrong shape *and* wrong color for 7 of the 8). The
+// in-world blockstate models (models/block/{tier}_copper_golem_statue.json)
+// DO carry the tier-correct particle texture, just never wired to the item
+// definition -- this map mirrors that per-tier association by item id.
+// Stopgap, not a real fix: still a flat icon, not a statue shape (no
+// vendored geometry exists to build one from -- see the GitHub issue this
+// links back to). Waxed variants use their un-waxed tier's texture (waxing
+// doesn't change current appearance, only halts further oxidation).
+const COPPER_GOLEM_STATUE_TIER_TEXTURES: Array<[needle: string, textureRef: string]> = [
+  ["oxidized_copper_golem_statue", "block/oxidized_copper"],
+  ["weathered_copper_golem_statue", "block/weathered_copper"],
+  ["exposed_copper_golem_statue", "block/exposed_copper"],
+];
+
+function copperGolemStatueTierTexture(itemId: string): string {
+  for (const [needle, textureRef] of COPPER_GOLEM_STATUE_TIER_TEXTURES) {
+    if (itemId.endsWith(needle)) return textureRef;
+  }
+  return "block/copper_block";
+}
+
 // Beds are the only `minecraft:composite` items (head + foot sub-models) and
 // the only ones using this bespoke multi-element parent. Used below to tell
 // which of a composite's two model refs is the head (see
@@ -499,6 +524,10 @@ export function resolveIconCandidate(
 
   if (special?.specialType === "banner" && typeof special.specialModel.color === "string") {
     return { type: "banner", colorId: special.specialModel.color };
+  }
+
+  if (special?.specialType === "copper_golem_statue") {
+    return { type: "flat", textureRef: copperGolemStatueTierTexture(itemId) };
   }
 
   const resolvedModelRef = modelRef ?? special?.base;

--- a/src/components/ItemIcon.astro
+++ b/src/components/ItemIcon.astro
@@ -494,7 +494,6 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
   .block .left-lower,
   .block .left-upper,
   .block .riser {
-    background-color: #fff;
     width: 100%;
     height: 100%;
     position: absolute;
@@ -509,23 +508,30 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
     object-fit: cover;
   }
 
+  /* var(--face-overlap) closes the same hairline sub-pixel seam between
+     adjacent faces that pressure_plate/button/wall/fence/fence_gate already
+     account for (see --face-overlap's definition) -- plain block/slab/
+     stairs faces used an opaque white background-color to paper over that
+     gap instead, which also opaquely masked any real alpha in the source
+     texture (e.g. copper_grate's cutout lattice rendered as solid white
+     behind the pattern instead of see-through). */
   .left,
   .left-lower,
   .left-upper {
-    transform: rotateY(-90deg) translateX(50%) rotateY(90deg);
+    transform: rotateY(-90deg) translateX(50%) rotateY(90deg) var(--face-overlap);
   }
 
   .right {
-    transform: translateX(50%) rotateY(90deg);
+    transform: translateX(50%) rotateY(90deg) var(--face-overlap);
   }
 
   .top {
-    transform: translateY(-50%) rotateX(90deg);
+    transform: translateY(-50%) rotateX(90deg) var(--face-overlap);
   }
 
   /* Slab: half-height box — top face drops to the container's mid-line, sides keep only their bottom half. */
   .block--slab .top {
-    transform: rotateX(90deg);
+    transform: rotateX(90deg) var(--face-overlap);
   }
 
   .block--slab .left,
@@ -538,13 +544,13 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
   .block--stairs .top-low {
     width: 50%;
     left: 50%;
-    transform: rotateX(90deg);
+    transform: rotateX(90deg) var(--face-overlap);
   }
 
   .block--stairs .top-high {
     width: 50%;
     left: 0;
-    transform: translateY(-50%) rotateX(90deg);
+    transform: translateY(-50%) rotateX(90deg) var(--face-overlap);
   }
 
   .block--stairs .left-lower {
@@ -567,7 +573,7 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
   .block--stairs .riser {
     height: 50%;
     top: 0;
-    transform: rotateY(90deg);
+    transform: rotateY(90deg) var(--face-overlap);
   }
 
   /* Pressure plate: a thin plank resting on the ground, inset 1px from every

--- a/src/components/ItemIcon.astro
+++ b/src/components/ItemIcon.astro
@@ -324,7 +324,19 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
 
 {
   item && (
-    <div class:list={['item-icon', { 'item-icon--block': is3d }]}>
+    <div
+      class:list={[
+        'item-icon',
+        {
+          // Two camera families, two --icon-scale/max-width pairs (see the
+          // derivation above .item-icon--block below) -- fence_gate runs its
+          // own shallower 30deg-pitch camera, every other 3D type shares the
+          // 35deg-pitch camera.
+          'item-icon--block': is3d && item.icon.type !== 'fence_gate',
+          'item-icon--fence-gate': item.icon.type === 'fence_gate',
+        },
+      ]}
+    >
       {item.icon.type === 'flat' ? (
         <img
           class="icon"
@@ -453,15 +465,73 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
     position: relative;
     aspect-ratio: 1/1;
     image-rendering: pixelated;
+    /* Every 3D engine below (.block/.wall/.fence/.fence-gate/.compound)
+       positions its faces by percentage against a local 0-100% reference
+       cube, then views it through a fixed rotateX/rotateY camera with NO
+       `perspective` set anywhere in this file -- i.e. a true orthographic
+       projection. Orthographically, a unit cube rotated by pitch φ then yaw
+       θ (`rotateX(φ) rotateY(θ)`) projects to a screen-space footprint of
+       |cosθ|+|sinθ| wide by |sinφ|(|sinθ|+|cosθ|)+|cosφ| tall, in multiples
+       of the cube's own edge (extrema land on the 8 corners for any affine
+       map of a box). At this file's 35deg/45-or-135deg camera that's
+       1.4142 x 1.6303 -- i.e. the reference cube ALWAYS overflows a 1x1 box
+       by ~63% in height, for every 3D icon type, not just compound ones.
+       This went unnoticed for cube-ish shapes (anvil, dirt, a wall) because
+       the bleed is symmetric on all 4 sides and was absorbed into the old
+       `max-width: 60%` whitespace margin below -- it only became visibly
+       broken for compound elements whose REAL geometry is flat/thin
+       (carpets height 1, snow height 2, trapdoors height 3, all out of 16):
+       the same 63% bleed concentrates entirely at the bottom edge instead of
+       spreading evenly, and pokes out of the box for real (most visibly the
+       item-hover tooltip's bordered card).
+
+       Fix: `--icon-scale` below (one constant per camera family -- see
+       `.item-icon--block`/`.item-icon--fence-gate`) is the exact reciprocal
+       of that projected height, prepended as `scale3d(...)` to each engine's
+       OWN top-level transform (`.block`/`.wall`/`.fence`/`.fence-gate`/
+       `.compound`). A uniform scale3d commutes with rotation and, applied on
+       the element that establishes a `preserve-3d` stack's shared 3D frame,
+       factors through every descendant's own transform untouched (matrix
+       algebra: parent's `kI * Rx * Ry` times any child's local matrix always
+       reduces to `k * (that child's original placement)`) -- so this needed
+       zero changes to computeFaceStyle, computeUvCrop, --face-overlap, or
+       any hand-authored per-face percentage anywhere below. `max-width`
+       grows by the same factor so already-shipped icons keep the exact same
+       on-screen size (the two changes are reciprocal by construction: old
+       content size = 0.6 * 1.6303 in cell-units; new content size =
+       (0.6 * 1.6303) * (1/1.6303), identical, just now bounded by the box's
+       own edge instead of by luck). Only now the box's edge genuinely is
+       the icon's edge, so `overflow: hidden` below is a real backstop (the
+       sub-1% fringe `--face-overlap` itself adds) rather than a crop of
+       real content. This is the single shared wrapper for every icon
+       type/context sitewide, and sits outside every engine's own
+       `preserve-3d` stack -- clipping here is a plain 2D box crop, not the
+       per-face `overflow: hidden` that caused compositor squashing (see
+       computeUvCrop's docstring); safe to contain unconditionally. */
+    overflow: hidden;
   }
 
   .item-icon--block {
-    max-width: 60%;
+    /* 1 / 1.6303 (see .item-icon's comment) -- the 35deg-pitch camera shared
+       by .block/.wall/.fence/.compound (45deg and 135deg yaw have identical
+       |cos|/|sin| magnitudes, so both cameras project to the same extent). */
+    --icon-scale: 0.6134;
+    max-width: 97.8155%;
     margin-inline: auto;
     /* Adjacent 3D faces that share a mathematically exact edge still rasterize
        with a hairline background gap (sub-pixel anti-aliasing). Appending this
        to a face's transform (i.e. applied first, in the face's own flat plane)
        overgrows every edge ~1.5% so neighboring faces overlap instead of abut. */
+    --face-overlap: scale(1.03);
+  }
+
+  .item-icon--fence-gate {
+    /* 1 / 1.5731 (see .item-icon's comment) -- fence-gate's own shallower
+       30deg-pitch camera (vanilla's GUI pitch for this model) projects a
+       shorter 1.5731 height, not .item-icon--block's 1.6303. */
+    --icon-scale: 0.6357;
+    max-width: 94.3879%;
+    margin-inline: auto;
     --face-overlap: scale(1.03);
   }
 
@@ -483,7 +553,8 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
     width: 100%;
     height: 100%;
     transform-style: preserve-3d;
-    transform: rotateX(-35deg) rotateY(-45deg);
+    transform: scale3d(var(--icon-scale), var(--icon-scale), var(--icon-scale)) rotateX(-35deg)
+      rotateY(-45deg);
   }
 
   .block .top,
@@ -639,7 +710,8 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
     position: absolute;
     inset: 0;
     transform-style: preserve-3d;
-    transform: rotateX(-35deg) rotateY(-45deg);
+    transform: scale3d(var(--icon-scale), var(--icon-scale), var(--icon-scale)) rotateX(-35deg)
+      rotateY(-45deg);
   }
 
   .wall__group {
@@ -717,7 +789,8 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
     position: absolute;
     inset: 0;
     transform-style: preserve-3d;
-    transform: rotateX(-35deg) rotateY(-45deg);
+    transform: scale3d(var(--icon-scale), var(--icon-scale), var(--icon-scale)) rotateX(-35deg)
+      rotateY(-45deg);
   }
 
   .fence__post,
@@ -834,7 +907,8 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
     position: absolute;
     inset: 0;
     transform-style: preserve-3d;
-    transform: rotateX(-30deg) rotateY(45deg);
+    transform: scale3d(var(--icon-scale), var(--icon-scale), var(--icon-scale)) rotateX(-30deg)
+      rotateY(45deg);
   }
 
   .fence-gate__el {
@@ -1001,7 +1075,8 @@ const fenceGateTexture = item && item.icon.type === 'fence_gate' ? withBase(item
     position: absolute;
     inset: 0;
     transform-style: preserve-3d;
-    transform: rotateX(-35deg) rotateY(-135deg) rotateY(var(--compound-y-rotation, 0deg));
+    transform: scale3d(var(--icon-scale), var(--icon-scale), var(--icon-scale)) rotateX(-35deg)
+      rotateY(-135deg) rotateY(var(--compound-y-rotation, 0deg));
   }
 
   /* Each face is TWO nested elements on purpose: cropping a transformed

--- a/src/data/generated/items.json
+++ b/src/data/generated/items.json
@@ -7407,7 +7407,7 @@
   },
   "exposed_copper_golem_statue": {
     "icon": {
-      "texture": "/textures/block/copper_block.png",
+      "texture": "/textures/block/exposed_copper.png",
       "type": "flat"
     },
     "id": "exposed_copper_golem_statue",
@@ -12921,7 +12921,7 @@
   },
   "oxidized_copper_golem_statue": {
     "icon": {
-      "texture": "/textures/block/copper_block.png",
+      "texture": "/textures/block/oxidized_copper.png",
       "type": "flat"
     },
     "id": "oxidized_copper_golem_statue",
@@ -18484,7 +18484,7 @@
   },
   "waxed_exposed_copper_golem_statue": {
     "icon": {
-      "texture": "/textures/block/copper_block.png",
+      "texture": "/textures/block/exposed_copper.png",
       "type": "flat"
     },
     "id": "waxed_exposed_copper_golem_statue",
@@ -18705,7 +18705,7 @@
   },
   "waxed_oxidized_copper_golem_statue": {
     "icon": {
-      "texture": "/textures/block/copper_block.png",
+      "texture": "/textures/block/oxidized_copper.png",
       "type": "flat"
     },
     "id": "waxed_oxidized_copper_golem_statue",
@@ -18917,7 +18917,7 @@
   },
   "waxed_weathered_copper_golem_statue": {
     "icon": {
-      "texture": "/textures/block/copper_block.png",
+      "texture": "/textures/block/weathered_copper.png",
       "type": "flat"
     },
     "id": "waxed_weathered_copper_golem_statue",
@@ -19138,7 +19138,7 @@
   },
   "weathered_copper_golem_statue": {
     "icon": {
-      "texture": "/textures/block/copper_block.png",
+      "texture": "/textures/block/weathered_copper.png",
       "type": "flat"
     },
     "id": "weathered_copper_golem_statue",


### PR DESCRIPTION
## Summary

Three related icon-accuracy fixes discovered while investigating a reported snow-icon overflow bug:

- **Every 3D icon has always overflowed its box.** All 5 CSS 3D engines (`.block`/`.wall`/`.fence`/`.fence-gate`/`.compound`) use an orthographic camera with no `perspective` set — a unit cube under `rotateX(35deg) rotateY(45-or-135deg)` projects to 1.4142×1.6303 of the box (1.4142×1.5731 for fence-gate's own shallower 30° pitch), always overflowing height by ~63%. This was invisible for cube-ish icons (bleed is symmetric, absorbed by the old `max-width: 60%` margin) but became visibly broken for thin/flat compound elements — carpets (height 1), snow (height 2), trapdoors (height 3) — where the same bleed concentrates entirely at the bottom edge and pokes out of bordered containers (most visibly the item-hover tooltip). Fix: a uniform `scale3d(k, k, k)` prepended to each engine's camera transform (k = the exact reciprocal of its projected height, one constant per camera family), with `max-width` grown by the reciprocal factor so already-shipped icons render pixel-identical to before. Verified this doesn't disturb `computeFaceStyle`/`computeUvCrop`/`--face-overlap` math (uniform scale on the `preserve-3d` root commutes with rotation and factors through every descendant unchanged) and confirmed empirically via pixel-measured before/after silhouette comparisons.
- **`copper_grate` (+ 22 other alpha-bearing icons)** rendered opaque — `.block .top/.left/.right` had an opaque white `background-color` behind the texture, compositing every transparent pixel against solid white. That backing was very likely there to mask a real, separate gap: these faces never used the `var(--face-overlap)` seam-closing trick that `pressure_plate`/`button`/`wall`/`fence`/`fence_gate` already have. Dropped the opaque background and added the seam fix properly. Affects the full grate family (8), plain `glass`/`tinted_glass`/`ice`, and all 16 stained-glass colors.
- **`copper_golem_statue`** (all 8 tier/waxed variants) rendered as a flat, tier-agnostic `copper_block` swatch — it's a `minecraft:special` entity-rendered item with zero vendored shape geometry, and its item-definition fallback texture doesn't vary by tier. The in-world blockstate models do carry the correct tier particle texture, just never wired to the item definition; resolved that per-tier texture by item id as a stopgap (still a flat icon, not a real statue shape — no vendored geometry exists to build one from).

## Test plan

- [x] `npm run format && npm run type-check && npm run lint && npm test && npm run build` — all green (184/184 tests, 0 type errors, 1121 pages)
- [x] `npm run parse && npm run validate` — regenerated data validated, byte-identical to committed (no drift)
- [x] Visually verified: snow/carpet/trapdoor now fully contained with no distortion (previously either bled outside their box or, in an earlier abandoned attempt, got visibly cropped); anvil/grindstone/composter/fence-gate/wall render pixel-consistent with before; copper_grate shows real transparency; all 4 copper_golem_statue oxidation tiers now show visually distinct colors instead of an identical flat swatch
- [x] Combined-fix check: copper_grate shows both transparency and correct containment simultaneously

https://claude.ai/code/session_013ga8yb2vDELdU9x9zZPDtA