### PR TITLE
feat: collapse copper's oxidation tiers into one catalog card per shape

### DIFF
--- a/src/utils/recipe-groups.ts
+++ b/src/utils/recipe-groups.ts
@@ -65,6 +65,34 @@ function normalizeVariantGroupKey(group: string | undefined): string | undefined
   return REDYE_GROUP_ALIASES[group] ?? group;
 }
 
+/**
+ * Strips copper's oxidation/waxing prefixes from a result item id, e.g.
+ * "waxed_exposed_cut_copper_slab" -> "cut_copper_slab". Vanilla's own
+ * `group` field doesn't reliably tie a copper shape's tiers together --
+ * some shapes only group their 4 waxed tiers (leaving the un-waxed base and
+ * un-waxed oxidized tiers stranded as singletons), others have no shared
+ * group at all across any tier -- so `groupRecipes` below derives a
+ * collapse key from the id itself for any result that has a sibling this
+ * stripping would unify (see `oxidationBases`). The bare block's tier ids
+ * ("waxed_exposed_copper", ...) strip to "copper", aliased to its own item
+ * id "copper_block" so the family collapses under the same key as its
+ * tiers. Every one of the ~78 ids this prefix set matches in the current
+ * generated data is copper or lightning-rod-family -- no wood/wool/color
+ * family id carries these prefixes, so this can't accidentally rope in an
+ * unrelated shape. In particular this leaves the `dyed_armor` group (which
+ * spans 6 *different* shapes -- leather boots/chestplate/helmet/leggings/
+ * horse armor + wolf armor, not color variants of one shape) alone: none
+ * of those ids match this prefix, so they still fall through to
+ * `members[0].group`-based derivation below (undefined for all 6, since
+ * their canonical recipes carry no group).
+ */
+const OXIDATION_TIER_PREFIX = /^(?:waxed_)?(?:exposed_|weathered_|oxidized_)?/;
+
+function stripOxidationPrefixes(resultId: string): string {
+  const base = resultId.replace(OXIDATION_TIER_PREFIX, "");
+  return base === "copper" ? "copper_block" : base;
+}
+
 export interface SiblingRecipe {
   recipeId: string;
   type: RecipeData["type"];
@@ -82,7 +110,7 @@ export interface RecipeGroup {
   resultId: string;
   family: string;
   familyId: string;
-  /** Normalized vanilla `group` field shared by this result's recipes (see normalizeVariantGroupKey), or undefined if none carry one. Used to fold same-shape/different-material result items into one tabbed VariantGroup -- see collapseVariantGroups. */
+  /** This result's collapse key -- an id-derived oxidation/waxing base (see stripOxidationPrefixes) when one applies, else the normalized vanilla `group` field shared by this result's recipes (see normalizeVariantGroupKey), else undefined. Used to fold same-shape/different-material result items into one tabbed VariantGroup -- see collapseVariantGroups. */
   variantKey: string | undefined;
   /** Alphabetically-first recipe id — the group's default/linked-to recipe. */
   canonicalId: string;
@@ -159,6 +187,22 @@ export function groupRecipes(
     }
   }
 
+  // Every base id that at least one oxidation/waxing tier strips down to
+  // (i.e. a shape with a tier actually present in this dataset). Computed
+  // as its own pass (not inline below) since a group needs to know whether
+  // any *other* result id shares its stripped form before it can tell
+  // whether this key would unify anything -- including its own un-prefixed
+  // base, which never contributes to this set itself (stripping is a
+  // no-op for it) but matches once a sibling tier has added it. A lone
+  // stripped id with no sibling just becomes a 1-member bucket, which
+  // collapseVariantGroups already demotes back to a plain singleton, so no
+  // count threshold is needed here.
+  const oxidationBases = new Set<string>();
+  for (const resultId of byResult.keys()) {
+    const stripped = stripOxidationPrefixes(resultId);
+    if (stripped !== resultId) oxidationBases.add(stripped);
+  }
+
   const groups: RecipeGroup[] = [];
 
   for (const [resultId, members] of byResult) {
@@ -218,11 +262,16 @@ export function groupRecipes(
       resolveLabelCollisions(siblings, lists, getItemName);
     }
 
+    const strippedResultId = stripOxidationPrefixes(resultId);
+    const variantKey = oxidationBases.has(strippedResultId)
+      ? strippedResultId
+      : normalizeVariantGroupKey(members[0].group);
+
     groups.push({
       resultId,
       family: familyDisplayName(members[0].family),
       familyId: members[0].family.id,
-      variantKey: normalizeVariantGroupKey(members[0].group),
+      variantKey,
       canonicalId: members[0].id,
       count,
       siblings,

--- a/tests/recipe-groups.test.ts
+++ b/tests/recipe-groups.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildRecipeHrefMap,
   canonicalRecipePath,
+  collapseVariantGroups,
   groupItemSlug,
   groupRecipes,
   indexByRecipeId,
@@ -258,6 +259,177 @@ describe("groupRecipes", () => {
       const labels = group.siblings.map((s) => s.label);
       expect(labels.every((label) => label !== null)).toBe(true);
       expect(new Set(labels).size).toBe(labels.length);
+    }
+  });
+});
+
+describe("collapseVariantGroups: copper oxidation-tier grouping", () => {
+  // Vanilla's own `group` field doesn't reliably tie a copper shape's tiers
+  // together (only some shapes group their 4 waxed tiers; the un-waxed base
+  // and un-waxed oxidized tiers are often left with no group at all) --
+  // groupRecipes derives an id-based collapse key from stripping copper's
+  // oxidation/waxing prefixes as a fallback/supplement, tested here directly
+  // against synthetic fixtures rather than only via the real generated data.
+  const copperShapeRecipes = (shape: string, tiers: string[]): RecipeData[] =>
+    tiers.map((tier) =>
+      recipe({
+        id: `${tier}${shape}`,
+        result: { id: `${tier}${shape}`, count: 1 },
+        ingredients: [{ items: ["copper_ingot"] }],
+      }),
+    );
+
+  it("unifies a shape's un-waxed base + oxidized tiers + waxed tiers into one VariantGroup", () => {
+    const recipes = copperShapeRecipes("cut_copper", [
+      "",
+      "exposed_",
+      "weathered_",
+      "oxidized_",
+      "waxed_",
+      "waxed_exposed_",
+      "waxed_weathered_",
+      "waxed_oxidized_",
+    ]);
+    const groups = groupRecipes(recipes, itemName);
+    const { variantGroups, singletons } = collapseVariantGroups(groups);
+
+    expect(singletons).toHaveLength(0);
+    expect(variantGroups).toHaveLength(1);
+    expect(variantGroups[0].groupKey).toBe("cut_copper");
+    expect(variantGroups[0].variants.map((v) => v.resultId).toSorted()).toEqual(
+      [
+        "cut_copper",
+        "exposed_cut_copper",
+        "oxidized_cut_copper",
+        "waxed_cut_copper",
+        "waxed_exposed_cut_copper",
+        "waxed_oxidized_cut_copper",
+        "waxed_weathered_cut_copper",
+        "weathered_cut_copper",
+      ].toSorted(),
+    );
+  });
+
+  it("unifies just the waxed tiers (no base recipe) under the bare shape id, e.g. copper_golem_statue", () => {
+    const recipes = copperShapeRecipes("copper_golem_statue", [
+      "waxed_",
+      "waxed_exposed_",
+      "waxed_weathered_",
+      "waxed_oxidized_",
+    ]);
+    const groups = groupRecipes(recipes, itemName);
+    const { variantGroups } = collapseVariantGroups(groups);
+
+    expect(variantGroups).toHaveLength(1);
+    expect(variantGroups[0].groupKey).toBe("copper_golem_statue");
+  });
+
+  it("aliases the bare block's tier ids (waxed_exposed_copper, ...) to copper_block, not the stripped bare 'copper'", () => {
+    // Vanilla's own bare-block ids are irregular: the base item is
+    // "copper_block", but its tier ids are "waxed_exposed_copper" etc --
+    // stripping those gives bare "copper", which stripOxidationPrefixes
+    // aliases to "copper_block" so this shape collapses under the same key
+    // as its own base item's id.
+    const tierIds = [
+      "waxed_copper",
+      "waxed_exposed_copper",
+      "waxed_weathered_copper",
+      "waxed_oxidized_copper",
+    ];
+    const recipes = [
+      recipe({
+        id: "copper_block",
+        result: { id: "copper_block", count: 1 },
+        ingredients: [{ items: ["copper_ingot"] }],
+      }),
+      ...tierIds.map((id) =>
+        recipe({ id, result: { id, count: 1 }, ingredients: [{ items: ["honeycomb"] }] }),
+      ),
+    ];
+    const groups = groupRecipes(recipes, itemName);
+    const { variantGroups } = collapseVariantGroups(groups);
+
+    expect(variantGroups).toHaveLength(1);
+    expect(variantGroups[0].groupKey).toBe("copper_block");
+    expect(variantGroups[0].variants.map((v) => v.resultId).toSorted()).toEqual(
+      ["copper_block", ...tierIds].toSorted(),
+    );
+  });
+
+  it("does not collapse a shape with only one recipe present (no siblings to unify)", () => {
+    const recipes = copperShapeRecipes("copper_torch", [""]);
+    const groups = groupRecipes(recipes, itemName);
+    const { variantGroups, singletons } = collapseVariantGroups(groups);
+
+    expect(variantGroups).toHaveLength(0);
+    expect(singletons).toHaveLength(1);
+    expect(singletons[0].variantKey).toBeUndefined();
+  });
+
+  it("never collapses dyed_armor (6 different shapes sharing a re-dye mechanism, not color variants of one shape)", () => {
+    // Mirrors the real data: each armor piece's OWN craft recipe has no
+    // group; only its "_dyed" sibling (a non-canonical, alphabetically-later
+    // recipe id) carries group: "dyed_armor" -- so the canonical recipe's
+    // group (what variantKey derives from) is undefined for every piece.
+    const recipes = [
+      recipe({
+        id: "leather_boots",
+        result: { id: "leather_boots", count: 1 },
+        ingredients: [{ items: ["leather"] }],
+      }),
+      recipe({
+        id: "leather_boots_dyed",
+        type: "special",
+        group: "dyed_armor",
+        result: { id: "leather_boots", count: 1 },
+        note: "Dye leather armor.",
+      }),
+      recipe({
+        id: "wolf_armor",
+        group: "dyed_armor",
+        result: { id: "wolf_armor", count: 1 },
+        ingredients: [{ items: ["armadillo_scute"] }],
+      }),
+    ];
+    const groups = groupRecipes(recipes, itemName);
+    const { variantGroups, singletons } = collapseVariantGroups(groups);
+
+    expect(variantGroups.find((vg) => vg.groupKey === "dyed_armor")).toBeUndefined();
+    // leather_boots' canonical recipe has no group at all (undefined);
+    // wolf_armor's sole/canonical recipe DOES carry group: "dyed_armor"
+    // directly, so it's a legitimate 1-member "dyed_armor" bucket --
+    // demoted to a singleton same as any other lone stripped/grouped id.
+    expect(singletons.map((s) => s.resultId).toSorted()).toEqual(["leather_boots", "wolf_armor"]);
+  });
+
+  it("loads the real generated recipe data and confirms copper shapes collapse without regressing dyed_armor", async () => {
+    const recipesModule = await import("../src/data/generated/recipes.json");
+    const allRecipes = Object.values(recipesModule.default) as RecipeData[];
+
+    const groups = groupRecipes(allRecipes, itemName);
+    const { variantGroups } = collapseVariantGroups(groups);
+
+    for (const shape of [
+      "cut_copper",
+      "cut_copper_slab",
+      "cut_copper_stairs",
+      "copper_bulb",
+      "copper_grate",
+    ]) {
+      const vg = variantGroups.find((v) => v.groupKey === shape);
+      expect(vg, `expected a VariantGroup for "${shape}"`).toBeDefined();
+      expect(vg!.variants.length).toBe(8);
+    }
+
+    expect(variantGroups.find((vg) => vg.groupKey === "dyed_armor")).toBeUndefined();
+    for (const resultId of [
+      "leather_boots",
+      "leather_chestplate",
+      "leather_helmet",
+      "wolf_armor",
+    ]) {
+      const group = groups.find((g) => g.resultId === resultId);
+      expect(group?.variantKey, `${resultId} must never get a variantKey`).toBeUndefined();
     }
   });
 });


### PR DESCRIPTION
## Summary

Copper's 15 shapes (bars, block, bulb, chain, chest, chiseled, cut, cut_slab, cut_stairs, door, golem_statue, grate, lantern, trapdoor) each showed as 4-8 separate catalog cards instead of collapsing into one tabbed card like every other material family (wool, wood, etc.) — because vanilla's own recipe `group` field is inconsistent for copper: some shapes only group their 4 waxed tiers (leaving the un-waxed base ungrouped), others have no shared group across any tier at all.

Derives the collapse key from the result item id instead (stripping `waxed_`/`exposed_`/`weathered_`/`oxidized_` prefixes) whenever a sibling result shares that stripped base, falling back to the existing group-field-based key otherwise. The one real false-positive risk — vanilla's `dyed_armor` group spans 6 unrelated shapes (leather armor pieces + wolf armor), not color variants of one shape — is guarded against by construction, since none of those ids carry the oxidation prefixes.

Pure client-side grouping logic; no vanilla-data, schema, or pipeline changes. Catalog shrinks by 50 cards (569 → 519).

## Test plan

- [x] `npm run format && npm run type-check && npm run lint && npm test && npm run build` — all green (195/195 tests, +6 new, 0 type errors, 1121 pages)
- [x] Verified against real generated data: all 6 fully-ungrouped copper shapes (chiseled/cut/cut_slab/cut_stairs/bulb/grate) now collapse to 8-variant cards; the 8 partially-grouped shapes (bars/block/chain/chest/door/lantern/trapdoor/lightning_rod) to 5-variant cards; copper_golem_statue to 4 (waxed tiers only, no base recipe exists)
- [x] Confirmed `dyed_armor` does NOT collapse (leather armor pieces + wolf armor stay separate cards) — new regression test added
- [x] Visually verified `/recipe/cut-copper/` shows all 8 oxidation tiers as tabs with correct per-tier icon colors

https://claude.ai/code/session_013ga8yb2vDELdU9x9zZPDtA