### PR TITLE
feat: curated collapsed-card identity + search face-swap

### DIFF
--- a/src/components/ItemIcon.astro
+++ b/src/components/ItemIcon.astro
@@ -1,5 +1,6 @@
 ---
 import { withBase } from '../utils/with-base';
+import { COMPOUND_FACE_DIRECTIONS, getFaces } from '../utils/icon-faces';
 import type { IconData } from '../content.config';
 
 interface Props {
@@ -10,43 +11,6 @@ interface Props {
   } | null;
   /** Native lazy-loading hint for the underlying &lt;img&gt;. Defaults to lazy. */
   loading?: 'lazy' | 'eager';
-}
-
-interface Face {
-  className: string;
-  texture: string;
-}
-
-/** Builds the CSS-cube faces for a 3D icon. `block`/`slab` share the 3-face cube; `stairs` adds a stepped tread. */
-function getFaces(icon: IconData): Face[] {
-  if (icon.type === 'stairs') {
-    return [
-      { className: 'top-low', texture: icon.top },
-      { className: 'top-high', texture: icon.top },
-      { className: 'left-lower', texture: icon.side },
-      { className: 'left-upper', texture: icon.side },
-      { className: 'right', texture: icon.side },
-      { className: 'riser', texture: icon.side },
-    ];
-  }
-
-  if (icon.type === 'block' || icon.type === 'slab') {
-    return [
-      { className: 'top', texture: icon.top },
-      { className: 'left', texture: icon.side },
-      { className: 'right', texture: icon.side },
-    ];
-  }
-
-  if (icon.type === 'pressure_plate' || icon.type === 'button') {
-    return [
-      { className: 'top', texture: icon.texture },
-      { className: 'left', texture: icon.texture },
-      { className: 'right', texture: icon.texture },
-    ];
-  }
-
-  return [];
 }
 
 interface CompoundFaceStyle {
@@ -267,7 +231,7 @@ function getCompoundFaces(icon: IconData): CompoundFacePart[] {
 
   const parts: CompoundFacePart[] = [];
   icon.elements.forEach((el, elIndex) => {
-    (['up', 'down', 'north', 'south', 'east', 'west'] as const).forEach((face) => {
+    COMPOUND_FACE_DIRECTIONS.forEach((face) => {
       const faceData = el.faces[face];
       if (!faceData) return;
       const style = computeFaceStyle(el.from, el.to, face);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,8 @@ import {
   groupDisplayName,
   groupItemSlug,
   groupRecipes,
+  variantGroupDefault,
+  variantGroupDisplayName,
   type RecipeGroup,
 } from '../utils/recipe-groups';
 import type { ItemData } from '../content.config';
@@ -52,12 +54,12 @@ interface CatalogCard {
 }
 
 const variantGroupCards: CatalogCard[] = variantGroups.map((variantGroup) => {
-  // variants[0] is the alphabetically-first result item -- this card's
-  // default/linked-to variant, same convention as RecipeGroup.canonicalId.
-  const defaultVariant = variantGroup.variants[0];
+  // The curated default variant/name (see VARIANT_GROUP_META) -- e.g. "Boat"
+  // showing the oak variant, not "Acacia Boat" from alphabetical-first.
+  const defaultVariant = variantGroupDefault(variantGroup);
   return {
     href: withBase(canonicalRecipePath(groupItemSlug(defaultVariant, itemsMap))),
-    name: groupDisplayName(defaultVariant, itemsMap),
+    name: variantGroupDisplayName(variantGroup, itemsMap),
     item: itemsMap.get(defaultVariant.resultId) ?? null,
     // Every variant's own name/labels/ingredients are searchable, not just
     // the default one shown -- searching "blue" should still surface the

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,6 +51,12 @@ interface CatalogCard {
   searchText: string;
   familyId: string;
   isShapeless: boolean;
+  // Set only for collapsed variant-group cards -- lets the client-side
+  // search "face-swap" (see the script below + variant-icons.json.ts)
+  // identify which cards are swappable and which variant they're currently
+  // showing. Absent (undefined) on singleton cards, which never swap.
+  variantGroupKey?: string;
+  defaultResultId?: string;
 }
 
 const variantGroupCards: CatalogCard[] = variantGroups.map((variantGroup) => {
@@ -67,6 +73,8 @@ const variantGroupCards: CatalogCard[] = variantGroups.map((variantGroup) => {
     searchText: variantGroup.variants.map(groupSearchText).join(' '),
     familyId: defaultVariant.familyId,
     isShapeless: variantGroup.variants.some(isGroupShapeless),
+    variantGroupKey: variantGroup.groupKey,
+    defaultResultId: defaultVariant.resultId,
   };
 });
 
@@ -143,7 +151,11 @@ const totalCards = cards.length;
       </p>
     </div>
 
-    <form class="catalog__filter" role="search">
+    <form
+      class="catalog__filter"
+      role="search"
+      data-variant-icons-url={withBase('/variant-icons.json')}
+    >
       <label for="recipe-filter" class="catalog__filter-label">Filter recipes by name</label>
       <div class="catalog__search-row">
         <input
@@ -259,6 +271,10 @@ const totalCards = cards.length;
                     data-category={category.categoryId}
                     data-family={family.familyId}
                     data-shapeless={card.isShapeless}
+                    data-variant-group={card.variantGroupKey}
+                    data-default-result-id={card.defaultResultId}
+                    data-default-name={card.variantGroupKey ? card.name : undefined}
+                    data-current-result-id={card.defaultResultId}
                   >
                     <ItemCard
                       href={card.href}
@@ -286,20 +302,126 @@ const totalCards = cards.length;
   const FAMILY_PARAM = 'family';
   const SHAPELESS_PARAM = 'shapeless';
 
+  // --- Search-driven variant "face-swap" ---------------------------------
+  // Collapsed variant cards (Boat, Banner, Cut Copper, ...) show one curated
+  // default variant (see VARIANT_GROUP_META). Searching a color/material
+  // adjective that names exactly one variant of a visible card (e.g.
+  // "acacia" while the Boat card shows its oak default) swaps that card's
+  // icon+name+link to the matched variant instead. The swap data
+  // (variant-icons.json.ts) is fetched lazily, only once the user actually
+  // searches for something -- never on page load -- and cached after that.
+  interface VariantIconEntry {
+    resultId: string;
+    name: string;
+    href: string;
+    textures: string[];
+  }
+  type VariantIconManifest = Record<string, VariantIconEntry[]>;
+
+  let variantManifestPromise: Promise<VariantIconManifest | null> | null = null;
+
+  function ensureVariantManifest(url: string): Promise<VariantIconManifest | null> {
+    if (!variantManifestPromise) {
+      variantManifestPromise = fetch(url)
+        .then((response) =>
+          response.ok ? (response.json() as Promise<VariantIconManifest>) : null,
+        )
+        .catch(() => null);
+    }
+    return variantManifestPromise;
+  }
+
+  // Every variant in a group shares identical geometry (see
+  // iconSwapTextures' doc comment) -- swapping is just pointing each
+  // already-rendered face at a different texture URL, positionally, never
+  // regenerating markup. A single-entry textures array (wall/fence/
+  // fence_gate icons, whose several parts all paint one shared texture) is
+  // broadcast to every slot instead of matched 1:1.
+  function applyTextures(iconContainer: Element, textures: string[]): boolean {
+    if (textures.length === 0) return false;
+    const slots = iconContainer.querySelectorAll<HTMLElement>('img, [style*="background-image"]');
+    if (slots.length === 0) return false;
+    slots.forEach((slot, index) => {
+      const texture = textures.length === 1 ? textures[0] : textures[index];
+      if (!texture) return;
+      if (slot instanceof HTMLImageElement) {
+        slot.src = texture;
+      } else {
+        slot.style.backgroundImage = `url(${texture})`;
+      }
+    });
+    return true;
+  }
+
+  function applyCardFace(card: HTMLElement, variant: VariantIconEntry) {
+    if (card.dataset.currentResultId === variant.resultId) return;
+    const iconContainer = card.querySelector('.item-card__icon');
+    const nameEl = card.querySelector('.item-card__name');
+    const linkEl = card.querySelector<HTMLAnchorElement>('a.item-card');
+    if (!iconContainer || !nameEl || !linkEl) return;
+    if (!applyTextures(iconContainer, variant.textures)) return;
+    nameEl.textContent = variant.name;
+    linkEl.href = variant.href;
+    card.dataset.currentResultId = variant.resultId;
+  }
+
   document.addEventListener('astro:page-load', () => {
     const form = document.querySelector<HTMLFormElement>('.catalog__filter');
     const input = document.getElementById('recipe-filter');
     const shapelessInput = document.getElementById('shapeless-toggle');
     const items = document.querySelectorAll<HTMLElement>('.catalog__item');
+    const variantGroupItems = document.querySelectorAll<HTMLElement>('[data-variant-group]');
     const categorySections = document.querySelectorAll<HTMLElement>('[data-category-section]');
     const familyGroups = document.querySelectorAll<HTMLElement>('[data-family-group]');
     const categoryInputs = document.querySelectorAll<HTMLInputElement>('input[name="category"]');
     const familyRadiogroups = document.querySelectorAll<HTMLElement>('[data-category-families]');
     const emptyState = document.getElementById('catalog-empty');
+    const variantIconsUrl = form?.dataset.variantIconsUrl;
 
     let activeCategory = 'all';
     let activeFamily = 'all';
     let shapelessOnly = false;
+
+    function updateVariantFaces(needle: string) {
+      if (!variantIconsUrl) return;
+      // Only ever fetch once the user has actually searched for something --
+      // an empty needle with no manifest fetched yet is a no-op (matches
+      // "avoid loading unless needed"). Once the manifest IS cached, still
+      // re-run on an empty needle so previously-swapped cards revert to
+      // their curated default.
+      if (!needle && !variantManifestPromise) return;
+
+      ensureVariantManifest(variantIconsUrl).then((manifest) => {
+        if (!manifest) return;
+        variantGroupItems.forEach((card) => {
+          const groupKey = card.dataset.variantGroup;
+          const defaultResultId = card.dataset.defaultResultId;
+          if (!groupKey || !defaultResultId) return;
+          const variants = manifest[groupKey];
+          if (!variants) return;
+
+          const matches = needle
+            ? variants.filter((variant) => variant.name.toLowerCase().includes(needle))
+            : [];
+
+          if (matches.length === 1) {
+            applyCardFace(card, matches[0]);
+            return;
+          }
+
+          // No specific match (or search cleared): show the family's
+          // curated identity, not the default variant's own item name --
+          // e.g. "Boat", not "Oak Boat" (see VARIANT_GROUP_META).
+          const defaultVariant = variants.find((variant) => variant.resultId === defaultResultId);
+          if (defaultVariant) {
+            applyCardFace(card, {
+              ...defaultVariant,
+              name: card.dataset.defaultName ?? defaultVariant.name,
+            });
+          }
+        });
+      });
+    }
 
     function activeFamilyInputs(): HTMLInputElement[] {
       const activeRadiogroup = document.querySelector<HTMLElement>(
@@ -334,6 +456,7 @@ const totalCards = cards.length;
       });
 
       if (emptyState) emptyState.hidden = anyVisible;
+      updateVariantFaces(needle);
     }
 
     function showFamilyRadiogroupForCategory() {

--- a/src/pages/variant-icons.json.ts
+++ b/src/pages/variant-icons.json.ts
@@ -1,0 +1,76 @@
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+import { withBase } from "../utils/with-base";
+import { iconSwapTextures, isIconGeometryUniform } from "../utils/icon-faces";
+import type { ItemData } from "../content.config";
+import {
+  canonicalRecipePath,
+  collapseVariantGroups,
+  groupDisplayName,
+  groupItemSlug,
+  groupRecipes,
+} from "../utils/recipe-groups";
+
+/**
+ * Lazily-fetched data for the homepage's client-side search "face-swap"
+ * (see index.astro): searching a color/material adjective that names
+ * exactly one variant of a collapsed card (e.g. "acacia" -> Acacia Boat)
+ * swaps that card's default face to the matched variant instead of always
+ * showing the family's curated default. Deliberately a separate static
+ * JSON endpoint, fetched only on the first search keystroke, rather than
+ * inlined into every homepage load or pre-rendered as hidden markup --
+ * pre-rendering every variant's full icon markup on the homepage itself was
+ * measured to nearly triple its HTML weight (+181%, ~1.45MB) for a search
+ * refinement most page loads never use. This payload is texture URLs only
+ * (no markup): within one collapsed group every variant shares identical
+ * geometry, so the client only ever swaps which texture an
+ * already-rendered slot points at -- see iconSwapTextures and
+ * index.astro's applyTextures.
+ *
+ * Not every group's members are actually geometry-identical (see
+ * isIconGeometryUniform's doc comment -- wooden_trapdoor's oak/dark_oak
+ * members use a different uv template than its other 10 woods, a real
+ * vanilla data split). For a non-uniform group, every member gets an empty
+ * `textures` array instead -- the client treats that as "no swap data" and
+ * leaves the card showing its curated default, rather than risk swapping in
+ * a mismatched crop.
+ */
+export const GET: APIRoute = async () => {
+  const recipeEntries = await getCollection("recipes");
+  const itemEntries = await getCollection("items");
+  const itemsMap = new Map(itemEntries.map((entry) => [entry.id, entry.data]));
+  const getItemName = (id: string) => itemsMap.get(id)?.name ?? id;
+
+  const groups = groupRecipes(
+    recipeEntries.map((entry) => entry.data),
+    getItemName,
+  );
+  const { variantGroups } = collapseVariantGroups(groups);
+
+  const manifest: Record<
+    string,
+    Array<{ resultId: string; name: string; href: string; textures: string[] }>
+  > = {};
+
+  for (const variantGroup of variantGroups) {
+    const icons = variantGroup.variants
+      .map((variant) => itemsMap.get(variant.resultId)?.icon)
+      .filter((icon): icon is ItemData["icon"] => icon !== undefined);
+    const swappable = isIconGeometryUniform(icons);
+
+    manifest[variantGroup.groupKey] = variantGroup.variants.map((variant) => {
+      const item = itemsMap.get(variant.resultId);
+      return {
+        resultId: variant.resultId,
+        name: groupDisplayName(variant, itemsMap),
+        href: withBase(canonicalRecipePath(groupItemSlug(variant, itemsMap))),
+        textures:
+          swappable && item ? iconSwapTextures(item.icon).map((texture) => withBase(texture)) : [],
+      };
+    });
+  }
+
+  return new Response(JSON.stringify(manifest), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/utils/icon-faces.ts
+++ b/src/utils/icon-faces.ts
@@ -1,0 +1,138 @@
+import type { IconData } from "../content.config";
+
+export interface Face {
+  className: string;
+  texture: string;
+}
+
+/** Builds the CSS-cube faces for a 3D icon. `block`/`slab` share the 3-face cube; `stairs` adds a stepped tread. */
+export function getFaces(icon: IconData): Face[] {
+  if (icon.type === "stairs") {
+    return [
+      { className: "top-low", texture: icon.top },
+      { className: "top-high", texture: icon.top },
+      { className: "left-lower", texture: icon.side },
+      { className: "left-upper", texture: icon.side },
+      { className: "right", texture: icon.side },
+      { className: "riser", texture: icon.side },
+    ];
+  }
+
+  if (icon.type === "block" || icon.type === "slab") {
+    return [
+      { className: "top", texture: icon.top },
+      { className: "left", texture: icon.side },
+      { className: "right", texture: icon.side },
+    ];
+  }
+
+  if (icon.type === "pressure_plate" || icon.type === "button") {
+    return [
+      { className: "top", texture: icon.texture },
+      { className: "left", texture: icon.texture },
+      { className: "right", texture: icon.texture },
+    ];
+  }
+
+  return [];
+}
+
+/**
+ * Fixed face iteration order for "compound" icons. Shared between
+ * ItemIcon.astro's getCompoundFaces (full style computation) and this file's
+ * iconSwapTextures (texture-only) so the two can never drift out of sync on
+ * ordering -- both must walk each element's faces in the exact same order
+ * for the homepage's positional texture-swap (see iconSwapTextures) to line
+ * up with what's actually rendered.
+ */
+export const COMPOUND_FACE_DIRECTIONS = ["up", "down", "north", "south", "east", "west"] as const;
+
+/**
+ * Ordered texture URLs for every already-rendered swappable slot of an icon
+ * -- powers the homepage's client-side search "face-swap" (see
+ * src/pages/variant-icons.json.ts + index.astro's applyTextures). Within one
+ * collapsed variant group (e.g. all 10 boat woods, all 16 banner colors),
+ * every member shares the exact same shape/geometry -- only the
+ * material/color differs -- so swapping to a different variant never needs
+ * to recompute layout/positioning, only which texture each already-rendered
+ * slot points at.
+ *
+ * Slot order/count matches ItemIcon.astro's own rendering exactly:
+ * getFaces()'s order for block-family icons (reused directly, so the two can
+ * never disagree on which texture goes on which face); a single-entry array
+ * for wall/fence/fence_gate, whose several parts all paint the same shared
+ * texture (the client broadcasts one entry to every slot -- see
+ * index.astro's applyTextures); and COMPOUND_FACE_DIRECTIONS order for
+ * "compound" icons, one entry per declared face.
+ */
+export function iconSwapTextures(icon: IconData): string[] {
+  if (icon.type === "flat") return [icon.texture];
+
+  if (icon.type === "wall" || icon.type === "fence" || icon.type === "fence_gate") {
+    return [icon.texture];
+  }
+
+  if (icon.type === "compound") {
+    const textures: string[] = [];
+    for (const element of icon.elements) {
+      for (const direction of COMPOUND_FACE_DIRECTIONS) {
+        const face = element.faces[direction];
+        if (face) textures.push(face.texture);
+      }
+    }
+    return textures;
+  }
+
+  return getFaces(icon).map((face) => face.texture);
+}
+
+/**
+ * Strips every texture-path field from an icon, leaving only the geometry
+ * (box coordinates, declared face directions, uv crop rects, rotation) --
+ * used by isIconGeometryUniform to check whether a texture-only swap is safe
+ * within a variant group. For every type except "compound", the type alone
+ * IS the full geometry (top/side/texture are the only per-type fields, and
+ * they're always texture paths), so any two same-type icons are trivially
+ * uniform; "compound" is the one type with real non-texture geometry (per-
+ * element from/to, per-face uv) that CAN legitimately differ between two
+ * same-shape items -- see isIconGeometryUniform's own comment.
+ */
+function iconGeometryFingerprint(icon: IconData): unknown {
+  if (icon.type !== "compound") return { type: icon.type };
+
+  return {
+    type: icon.type,
+    yRotation: icon.yRotation,
+    variant: icon.variant,
+    elements: icon.elements.map((element) => ({
+      from: element.from,
+      to: element.to,
+      faces: Object.fromEntries(
+        COMPOUND_FACE_DIRECTIONS.filter((direction) => element.faces[direction]).map(
+          (direction) => [direction, { uv: element.faces[direction]!.uv }],
+        ),
+      ),
+    })),
+  };
+}
+
+/**
+ * Whether every icon in a variant group shares byte-identical geometry (see
+ * iconGeometryFingerprint), i.e. whether iconSwapTextures' texture-URL-only
+ * swap is safe for this group. This does NOT always hold: verified against
+ * the real generated data (see tests/icon-faces.test.ts's regression test),
+ * 41 of 42 current variant groups pass, but wooden_trapdoor's oak/dark_oak
+ * members use vanilla's legacy non-orientable trapdoor template (different
+ * per-face uv rects -- flipped/offset top and side crops) while its other 10
+ * woods use the newer orientable template -- a real vanilla data split, not
+ * a pipeline bug (see scripts/lib/model.ts and vendor/mcmeta-summary's
+ * template_trapdoor_bottom vs template_orientable_trapdoor_bottom). A future
+ * mcmeta version bump could introduce a similar split in a currently-uniform
+ * group; this check lets a caller (variant-icons.json.ts) degrade that one
+ * group safely (omit its swap textures) without a hand-maintained denylist.
+ */
+export function isIconGeometryUniform(icons: IconData[]): boolean {
+  if (icons.length <= 1) return true;
+  const [first, ...rest] = icons.map((icon) => JSON.stringify(iconGeometryFingerprint(icon)));
+  return rest.every((fingerprint) => fingerprint === first);
+}

--- a/src/utils/recipe-groups.ts
+++ b/src/utils/recipe-groups.ts
@@ -333,6 +333,98 @@ export function collapseVariantGroups(groups: RecipeGroup[]): {
   return { variantGroups, singletons };
 }
 
+export interface VariantGroupMeta {
+  /** Generic display name for the collapsed card, e.g. "Boat" not "Acacia Boat". */
+  name: string;
+  /** The variant shown as the card's default/linked-to face, e.g. "oak_boat" not the alphabetically-first "acacia_boat". Falls back to variants[0] if unset or not found (shouldn't happen for a real groupKey -- see the completeness test in tests/recipe-groups.test.ts). */
+  defaultResultId?: string;
+}
+
+/**
+ * Curated identity for every VariantGroup, keyed by groupKey. Without this,
+ * a collapsed card's name/icon default to its alphabetically-first variant
+ * (e.g. "Acacia Boat" representing the whole 10-wood-type Boats family) --
+ * which reads as one specific item, not the generic shape the card actually
+ * represents. Every key here must match a real groupKey collapseVariantGroups
+ * can produce; tests/recipe-groups.test.ts asserts this map's keys are a
+ * superset of every groupKey the real generated data currently produces (a
+ * missing entry isn't a hard error -- variantGroupDisplayName/
+ * variantGroupDefault both fall back gracefully -- but it silently
+ * regresses to the alphabetical-default problem this map exists to fix).
+ */
+export const VARIANT_GROUP_META: Record<string, VariantGroupMeta> = {
+  // Color families -- default to white except where vanilla's own
+  // iconography favors a different color (bed: red is the classic
+  // Minecraft bed color; shulker box: purple is the vanilla shulker's own
+  // color).
+  banner: { name: "Banner", defaultResultId: "white_banner" },
+  bed: { name: "Bed", defaultResultId: "red_bed" },
+  bundle_dye: { name: "Dyed Bundle", defaultResultId: "white_bundle" },
+  carpet: { name: "Carpet", defaultResultId: "white_carpet" },
+  concrete_powder: { name: "Concrete Powder", defaultResultId: "white_concrete_powder" },
+  dyed_candle: { name: "Dyed Candle", defaultResultId: "white_candle" },
+  harness: { name: "Harness", defaultResultId: "white_harness" },
+  shulker_box_dye: { name: "Dyed Shulker Box", defaultResultId: "purple_shulker_box" },
+  stained_glass: { name: "Stained Glass", defaultResultId: "white_stained_glass" },
+  stained_glass_pane: { name: "Stained Glass Pane", defaultResultId: "white_stained_glass_pane" },
+  stained_terracotta: { name: "Dyed Terracotta", defaultResultId: "white_terracotta" },
+  wool: { name: "Wool", defaultResultId: "white_wool" },
+  // Wood families -- default to oak, the wood type most players picture first.
+  bark: { name: "Wood & Hyphae", defaultResultId: "oak_wood" },
+  boat: { name: "Boat", defaultResultId: "oak_boat" },
+  chest_boat: { name: "Boat with Chest", defaultResultId: "oak_chest_boat" },
+  planks: { name: "Planks", defaultResultId: "oak_planks" },
+  shelf: { name: "Shelf", defaultResultId: "oak_shelf" },
+  wooden_button: { name: "Wooden Button", defaultResultId: "oak_button" },
+  wooden_door: { name: "Wooden Door", defaultResultId: "oak_door" },
+  wooden_fence: { name: "Wooden Fence", defaultResultId: "oak_fence" },
+  wooden_fence_gate: { name: "Fence Gate", defaultResultId: "oak_fence_gate" },
+  wooden_hanging_sign: { name: "Hanging Sign", defaultResultId: "oak_hanging_sign" },
+  wooden_pressure_plate: { name: "Wooden Pressure Plate", defaultResultId: "oak_pressure_plate" },
+  wooden_sign: { name: "Sign", defaultResultId: "oak_sign" },
+  wooden_slab: { name: "Wooden Slab", defaultResultId: "oak_slab" },
+  wooden_stairs: { name: "Wooden Stairs", defaultResultId: "oak_stairs" },
+  wooden_trapdoor: { name: "Wooden Trapdoor", defaultResultId: "oak_trapdoor" },
+  // Copper oxidation families -- default to the clean, un-oxidized base
+  // tier (golem_statue has no base-tier recipe, so its earliest waxed tier).
+  chiseled_copper: { name: "Chiseled Copper", defaultResultId: "chiseled_copper" },
+  copper_bars: { name: "Copper Bars", defaultResultId: "copper_bars" },
+  copper_block: { name: "Block of Copper", defaultResultId: "copper_block" },
+  copper_bulb: { name: "Copper Bulb", defaultResultId: "copper_bulb" },
+  copper_chain: { name: "Copper Chain", defaultResultId: "copper_chain" },
+  copper_chest: { name: "Copper Chest", defaultResultId: "copper_chest" },
+  copper_door: { name: "Copper Door", defaultResultId: "copper_door" },
+  copper_golem_statue: {
+    name: "Copper Golem Statue",
+    defaultResultId: "waxed_copper_golem_statue",
+  },
+  copper_grate: { name: "Copper Grate", defaultResultId: "copper_grate" },
+  copper_lantern: { name: "Copper Lantern", defaultResultId: "copper_lantern" },
+  copper_trapdoor: { name: "Copper Trapdoor", defaultResultId: "copper_trapdoor" },
+  cut_copper: { name: "Cut Copper", defaultResultId: "cut_copper" },
+  cut_copper_slab: { name: "Cut Copper Slab", defaultResultId: "cut_copper_slab" },
+  cut_copper_stairs: { name: "Cut Copper Stairs", defaultResultId: "cut_copper_stairs" },
+  lightning_rod: { name: "Lightning Rod", defaultResultId: "lightning_rod" },
+};
+
+/** The VariantGroup's display name -- curated (see VARIANT_GROUP_META) where one exists, else the default variant's own item name. */
+export function variantGroupDisplayName(
+  variantGroup: VariantGroup,
+  itemsMap: Map<string, ItemData>,
+): string {
+  const meta = VARIANT_GROUP_META[variantGroup.groupKey];
+  return meta?.name ?? groupDisplayName(variantGroupDefault(variantGroup), itemsMap);
+}
+
+/** The VariantGroup's default/linked-to variant -- curated (see VARIANT_GROUP_META) where one exists and resolves to a real member, else variants[0] (alphabetically-first, matching RecipeGroup.canonicalId's own convention). */
+export function variantGroupDefault(variantGroup: VariantGroup): RecipeGroup {
+  const defaultResultId = VARIANT_GROUP_META[variantGroup.groupKey]?.defaultResultId;
+  const curated = defaultResultId
+    ? variantGroup.variants.find((variant) => variant.resultId === defaultResultId)
+    : undefined;
+  return curated ?? variantGroup.variants[0];
+}
+
 /** Looks up a recipe's group by its own recipe id (not just the canonical id). */
 export function indexByRecipeId(groups: RecipeGroup[]): Map<string, RecipeGroup> {
   const map = new Map<string, RecipeGroup>();

--- a/tests/icon-faces.test.ts
+++ b/tests/icon-faces.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import { getFaces, iconSwapTextures, isIconGeometryUniform } from "../src/utils/icon-faces";
+import { collapseVariantGroups, groupRecipes } from "../src/utils/recipe-groups";
+import type { IconData, RecipeData } from "../src/content.config";
+
+const itemName = (id: string) => id;
+
+const compoundIconWithTexture = (texture: string): IconData => ({
+  type: "compound",
+  yRotation: 0,
+  elements: [
+    {
+      from: [0, 0, 0],
+      to: [16, 16, 16],
+      faces: { up: { texture, uv: [0, 0, 16, 16] } },
+    },
+  ],
+});
+
+describe("getFaces", () => {
+  it("returns no faces for a flat icon", () => {
+    expect(getFaces({ type: "flat", texture: "/textures/item/stick.png" })).toEqual([]);
+  });
+
+  it("returns top/left/right for a block, mapping left+right to the side texture", () => {
+    const icon: IconData = { type: "block", top: "/top.png", side: "/side.png" };
+    expect(getFaces(icon)).toEqual([
+      { className: "top", texture: "/top.png" },
+      { className: "left", texture: "/side.png" },
+      { className: "right", texture: "/side.png" },
+    ]);
+  });
+
+  it("returns the same 3-face shape for a slab", () => {
+    const icon: IconData = { type: "slab", top: "/top.png", side: "/side.png" };
+    expect(getFaces(icon)).toEqual([
+      { className: "top", texture: "/top.png" },
+      { className: "left", texture: "/side.png" },
+      { className: "right", texture: "/side.png" },
+    ]);
+  });
+
+  it("returns 6 stepped-tread faces for stairs", () => {
+    const icon: IconData = { type: "stairs", top: "/top.png", side: "/side.png" };
+    expect(getFaces(icon)).toEqual([
+      { className: "top-low", texture: "/top.png" },
+      { className: "top-high", texture: "/top.png" },
+      { className: "left-lower", texture: "/side.png" },
+      { className: "left-upper", texture: "/side.png" },
+      { className: "right", texture: "/side.png" },
+      { className: "riser", texture: "/side.png" },
+    ]);
+  });
+
+  it("returns top/left/right all from the single texture for pressure_plate and button", () => {
+    const plate: IconData = { type: "pressure_plate", texture: "/plate.png" };
+    const button: IconData = { type: "button", texture: "/button.png" };
+    expect(getFaces(plate)).toEqual([
+      { className: "top", texture: "/plate.png" },
+      { className: "left", texture: "/plate.png" },
+      { className: "right", texture: "/plate.png" },
+    ]);
+    expect(getFaces(button)).toEqual([
+      { className: "top", texture: "/button.png" },
+      { className: "left", texture: "/button.png" },
+      { className: "right", texture: "/button.png" },
+    ]);
+  });
+
+  it("returns no faces for wall/fence/fence_gate/compound (rendered via their own multi-part markup, not getFaces' li list)", () => {
+    expect(getFaces({ type: "wall", texture: "/wall.png" })).toEqual([]);
+    expect(getFaces({ type: "fence", texture: "/fence.png" })).toEqual([]);
+    expect(getFaces({ type: "fence_gate", texture: "/gate.png" })).toEqual([]);
+    expect(getFaces({ type: "compound", elements: [], yRotation: 0 })).toEqual([]);
+  });
+});
+
+describe("iconSwapTextures", () => {
+  it("returns a single-entry array for flat", () => {
+    expect(iconSwapTextures({ type: "flat", texture: "/stick.png" })).toEqual(["/stick.png"]);
+  });
+
+  it("returns the 3-entry getFaces order for block", () => {
+    const icon: IconData = { type: "block", top: "/top.png", side: "/side.png" };
+    expect(iconSwapTextures(icon)).toEqual(["/top.png", "/side.png", "/side.png"]);
+  });
+
+  it("returns the 6-entry getFaces order for stairs", () => {
+    const icon: IconData = { type: "stairs", top: "/top.png", side: "/side.png" };
+    expect(iconSwapTextures(icon)).toEqual([
+      "/top.png",
+      "/top.png",
+      "/side.png",
+      "/side.png",
+      "/side.png",
+      "/side.png",
+    ]);
+  });
+
+  it("returns a single-entry array for wall/fence/fence_gate, broadcast client-side to every same-texture slot", () => {
+    expect(iconSwapTextures({ type: "wall", texture: "/wall.png" })).toEqual(["/wall.png"]);
+    expect(iconSwapTextures({ type: "fence", texture: "/fence.png" })).toEqual(["/fence.png"]);
+    expect(iconSwapTextures({ type: "fence_gate", texture: "/gate.png" })).toEqual(["/gate.png"]);
+  });
+
+  it("walks compound elements/faces in COMPOUND_FACE_DIRECTIONS order, skipping undeclared faces", () => {
+    const icon: IconData = {
+      type: "compound",
+      yRotation: 0,
+      elements: [
+        {
+          from: [0, 0, 0],
+          to: [16, 16, 16],
+          faces: {
+            up: { texture: "/up.png", uv: [0, 0, 16, 16] },
+            south: { texture: "/south.png", uv: [0, 0, 16, 16] },
+          },
+        },
+        {
+          from: [0, 0, 0],
+          to: [8, 8, 8],
+          faces: {
+            east: { texture: "/east.png", uv: [0, 0, 16, 16] },
+          },
+        },
+      ],
+    };
+    // up/down/north/south/east/west order, per element, in declaration order --
+    // element 0 only declares up+south (down/north/east/west absent, skipped).
+    expect(iconSwapTextures(icon)).toEqual(["/up.png", "/south.png", "/east.png"]);
+  });
+
+  it("returns [] for an empty compound (no elements)", () => {
+    expect(iconSwapTextures({ type: "compound", elements: [], yRotation: 0 })).toEqual([]);
+  });
+});
+
+describe("isIconGeometryUniform", () => {
+  it("treats any two same-type non-compound icons as uniform regardless of texture paths", () => {
+    const a: IconData = { type: "block", top: "/oak-top.png", side: "/oak-side.png" };
+    const b: IconData = { type: "block", top: "/spruce-top.png", side: "/spruce-side.png" };
+    expect(isIconGeometryUniform([a, b])).toBe(true);
+  });
+
+  it("treats a group with fewer than 2 icons as trivially uniform", () => {
+    expect(isIconGeometryUniform([])).toBe(true);
+    expect(isIconGeometryUniform([{ type: "flat", texture: "/stick.png" }])).toBe(true);
+  });
+
+  it("treats compound icons with the same from/to/uv/faces/yRotation as uniform, ignoring texture paths", () => {
+    expect(
+      isIconGeometryUniform([
+        compoundIconWithTexture("/white.png"),
+        compoundIconWithTexture("/red.png"),
+      ]),
+    ).toBe(true);
+  });
+
+  it("flags compound icons with a different uv rect as non-uniform (the real wooden_trapdoor case)", () => {
+    const orientable: IconData = {
+      type: "compound",
+      yRotation: 0,
+      elements: [
+        {
+          from: [0, 0, 0],
+          to: [16, 16, 3],
+          faces: { south: { texture: "/spruce_trapdoor.png", uv: [0, 0, 16, 3] } },
+        },
+      ],
+    };
+    const legacy: IconData = {
+      type: "compound",
+      yRotation: 0,
+      elements: [
+        {
+          from: [0, 0, 0],
+          to: [16, 16, 3],
+          faces: { south: { texture: "/oak_trapdoor.png", uv: [0, 16, 16, 13] } },
+        },
+      ],
+    };
+    expect(isIconGeometryUniform([orientable, legacy])).toBe(false);
+  });
+
+  it("flags compound icons with different from/to, declared faces, or yRotation as non-uniform", () => {
+    const base: IconData = {
+      type: "compound",
+      yRotation: 0,
+      elements: [
+        {
+          from: [0, 0, 0],
+          to: [16, 16, 16],
+          faces: { up: { texture: "/a.png", uv: [0, 0, 16, 16] } },
+        },
+      ],
+    };
+    const differentTo: IconData = {
+      ...base,
+      elements: [{ ...base.elements[0], to: [16, 8, 16] }],
+    };
+    const differentFaces: IconData = {
+      ...base,
+      elements: [
+        {
+          ...base.elements[0],
+          faces: {
+            up: base.elements[0].faces.up!,
+            south: { texture: "/b.png", uv: [0, 0, 16, 16] },
+          },
+        },
+      ],
+    };
+    const differentYRotation: IconData = { ...base, yRotation: 90 };
+
+    expect(isIconGeometryUniform([base, differentTo])).toBe(false);
+    expect(isIconGeometryUniform([base, differentFaces])).toBe(false);
+    expect(isIconGeometryUniform([base, differentYRotation])).toBe(false);
+  });
+
+  it("loads the real generated data and confirms every variant group is geometry-uniform except the known wooden_trapdoor split", async () => {
+    // wooden_trapdoor: oak/dark_oak parent to vanilla's legacy
+    // template_trapdoor_bottom (non-orientable uv); the other 10 woods
+    // parent to the newer template_orientable_trapdoor_bottom -- a real
+    // vanilla data split (verified against vendor/mcmeta-summary), not a
+    // pipeline bug. variant-icons.json.ts's isIconGeometryUniform check
+    // already degrades this one group safely (empty swap textures); this
+    // test's real job is failing loudly if a FUTURE mcmeta bump introduces
+    // a similar split in some other, currently-uniform group.
+    const KNOWN_NONUNIFORM_GROUPS = new Set(["wooden_trapdoor"]);
+
+    const recipesModule = await import("../src/data/generated/recipes.json");
+    const itemsModule = await import("../src/data/generated/items.json");
+    const allRecipes = Object.values(recipesModule.default) as RecipeData[];
+    const items = itemsModule.default as unknown as Record<string, { icon: IconData }>;
+
+    const groups = groupRecipes(allRecipes, itemName);
+    const { variantGroups } = collapseVariantGroups(groups);
+    expect(variantGroups.length).toBeGreaterThan(0);
+
+    const unexpectedlyNonUniform = variantGroups
+      .filter((vg) => !KNOWN_NONUNIFORM_GROUPS.has(vg.groupKey))
+      .filter((vg) => {
+        const icons = vg.variants
+          .map((v) => items[v.resultId]?.icon)
+          .filter((icon) => icon != null);
+        return !isIconGeometryUniform(icons);
+      })
+      .map((vg) => vg.groupKey);
+
+    expect(
+      unexpectedlyNonUniform,
+      `new geometry split found outside the known exception list: ${unexpectedlyNonUniform}`,
+    ).toEqual([]);
+
+    // The known exception must still actually be non-uniform -- if a future
+    // mcmeta bump ever normalizes oak/dark_oak onto the orientable template,
+    // this should fail so the exception list gets cleaned up, not left stale.
+    const trapdoorGroup = variantGroups.find((vg) => vg.groupKey === "wooden_trapdoor");
+    if (trapdoorGroup) {
+      const icons = trapdoorGroup.variants
+        .map((v) => items[v.resultId]?.icon)
+        .filter((icon) => icon != null);
+      expect(isIconGeometryUniform(icons)).toBe(false);
+    }
+  });
+});

--- a/tests/recipe-groups.test.ts
+++ b/tests/recipe-groups.test.ts
@@ -7,6 +7,9 @@ import {
   groupRecipes,
   indexByRecipeId,
   recipePath,
+  VARIANT_GROUP_META,
+  variantGroupDefault,
+  variantGroupDisplayName,
 } from "../src/utils/recipe-groups";
 import type { ItemData, RecipeData } from "../src/content.config";
 
@@ -430,6 +433,82 @@ describe("collapseVariantGroups: copper oxidation-tier grouping", () => {
     ]) {
       const group = groups.find((g) => g.resultId === resultId);
       expect(group?.variantKey, `${resultId} must never get a variantKey`).toBeUndefined();
+    }
+  });
+});
+
+describe("variantGroupDisplayName / variantGroupDefault", () => {
+  it("uses the curated name/default when a VARIANT_GROUP_META entry exists", () => {
+    const recipes = [
+      recipe({ id: "acacia_boat", group: "boat", result: { id: "acacia_boat", count: 1 } }),
+      recipe({ id: "oak_boat", group: "boat", result: { id: "oak_boat", count: 1 } }),
+    ];
+    const groups = groupRecipes(recipes, itemName);
+    const [variantGroup] = collapseVariantGroups(groups).variantGroups;
+    const itemsMap = new Map([
+      ["acacia_boat", item({ id: "acacia_boat" })],
+      ["oak_boat", item({ id: "oak_boat" })],
+    ]);
+
+    expect(variantGroupDisplayName(variantGroup, itemsMap)).toBe("Boat");
+    expect(variantGroupDefault(variantGroup).resultId).toBe("oak_boat");
+  });
+
+  it("falls back to the alphabetically-first variant's own name when no meta entry exists", () => {
+    const recipes = [
+      recipe({ id: "made_up_a", group: "made_up_group", result: { id: "made_up_a", count: 1 } }),
+      recipe({ id: "made_up_b", group: "made_up_group", result: { id: "made_up_b", count: 1 } }),
+    ];
+    const groups = groupRecipes(recipes, itemName);
+    const [variantGroup] = collapseVariantGroups(groups).variantGroups;
+    const itemsMap = new Map([
+      ["made_up_a", item({ id: "made_up_a", name: "Made Up A" })],
+      ["made_up_b", item({ id: "made_up_b", name: "Made Up B" })],
+    ]);
+
+    expect(variantGroupDisplayName(variantGroup, itemsMap)).toBe("Made Up A");
+    expect(variantGroupDefault(variantGroup).resultId).toBe("made_up_a");
+  });
+
+  it("falls back to variants[0] if a meta entry's defaultResultId doesn't match any real member", () => {
+    // Defensive case -- shouldn't happen for a real groupKey, but a stale/
+    // mistyped defaultResultId must not throw or silently return undefined.
+    const recipes = [
+      recipe({ id: "acacia_boat", group: "boat", result: { id: "acacia_boat", count: 1 } }),
+      recipe({ id: "birch_boat", group: "boat", result: { id: "birch_boat", count: 1 } }),
+    ];
+    const groups = groupRecipes(recipes, itemName);
+    const [variantGroup] = collapseVariantGroups(groups).variantGroups;
+
+    // "boat"'s real meta points at "oak_boat", which isn't a member of this
+    // fixture's 2-variant group -- must fall back to variants[0], not throw.
+    expect(variantGroupDefault(variantGroup).resultId).toBe("acacia_boat");
+  });
+
+  it("loads the real generated recipe data and confirms VARIANT_GROUP_META covers every groupKey", async () => {
+    const recipesModule = await import("../src/data/generated/recipes.json");
+    const allRecipes = Object.values(recipesModule.default) as RecipeData[];
+
+    const groups = groupRecipes(allRecipes, itemName);
+    const { variantGroups } = collapseVariantGroups(groups);
+    const missing = variantGroups
+      .map((vg) => vg.groupKey)
+      .filter((groupKey) => !(groupKey in VARIANT_GROUP_META));
+
+    expect(
+      missing,
+      `every real groupKey needs a VARIANT_GROUP_META entry, missing: ${missing}`,
+    ).toEqual([]);
+
+    // Every curated defaultResultId must resolve to a real member of its
+    // own group -- catches a typo'd id before it silently falls back.
+    for (const variantGroup of variantGroups) {
+      const defaultResultId = VARIANT_GROUP_META[variantGroup.groupKey]?.defaultResultId;
+      if (!defaultResultId) continue;
+      expect(
+        variantGroup.variants.some((v) => v.resultId === defaultResultId),
+        `VARIANT_GROUP_META["${variantGroup.groupKey}"].defaultResultId "${defaultResultId}" is not a real member`,
+      ).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Summary

**Step 2 — curated names/defaults**
- Collapsed variant cards (boat, planks, stairs, copper families, etc.) previously showed the alphabetically-first variant's own name/icon (e.g. "Acacia Boat" representing all 10 boat types)
- Adds a curated `VARIANT_GROUP_META` map (42 entries, one per current `groupKey`) so each collapsed card shows a generic family name and a sensible default variant (oak for wood families, base tier for copper, vanilla-conventional color for dye families)
- Falls back to the prior alphabetical behavior for any group without a curated entry

**Step 3 — search-driven face-swap**
- Searching a color/material adjective that names exactly one variant of a collapsed card (e.g. "acacia" while the Boat card shows its curated oak default) now swaps that card's icon+name+link to the matched variant
- Measured the naive approach first: pre-rendering every variant's full icon markup on the homepage would have added ~1.45MB of HTML (+181% page weight). Instead, `variant-icons.json.ts` is a static endpoint of just texture URLs/names, fetched lazily on the first search keystroke (never on page load)
- Swapping is a positional texture-URL swap on the already-rendered DOM (same geometry within a group, only material/color differs) — never markup regeneration or client-side 3D geometry math. Verified against the real generated data (with Fable) that this holds for 41 of 42 groups; the one exception (`wooden_trapdoor`, a real vanilla legacy-UV-template split) is auto-detected and degrades safely to "no swap," with a regression test to catch any future mcmeta bump that introduces a similar split elsewhere

## Test plan
- [x] `npm run format && npm run type-check && npm run lint && npm test && npm run build` all pass (217 tests)
- [x] Completeness test asserts `VARIANT_GROUP_META`'s keys are a superset of every real `groupKey`, and every curated `defaultResultId` resolves to a real member
- [x] Regression test asserts every real variant group is geometry-uniform except the documented `wooden_trapdoor` exception
- [x] Browser-verified (Playwright): lazy-fetch only triggers on first search keystroke; "acacia" swaps the Boat card to the correct texture/name/href; generic "boat" search and clearing the search both correctly revert to the curated "Boat" identity (not the item's own name); compound icons (Banner, 15-face swap) render correctly; `wooden_trapdoor` correctly never swaps; independent multi-group matching (searching "red" swaps Wool/Carpet/Stained Glass/Shulker Box independently) works correctly

https://claude.ai/code/session_013ga8yb2vDELdU9x9zZPDtA