### PR TITLE
fix: prefer .new lang keys for item display names

### DIFF
--- a/scripts/lib/lang.ts
+++ b/scripts/lib/lang.ts
@@ -1,11 +1,27 @@
 import { titleCaseFromId } from "./strings.ts";
 
 /**
+ * Resolves a single lang key, preferring Mojang's `<key>.new` variant when
+ * present. Mojang ships renamed display strings as a `<key>.new` entry
+ * alongside the original `<key>` (kept for old resource-pack compatibility)
+ * -- e.g. smithing templates ("Smithing Template" -> "Netherite Upgrade")
+ * and some banner patterns ("Banner Pattern" -> "Creeper Charge Banner
+ * Pattern") were renamed this way. This rule is generic over every lang key,
+ * current or future: a data bump that adds more `.new` renames needs zero
+ * code changes to pick them up.
+ */
+export function resolveLangKey(key: string, enUs: Record<string, string>): string | undefined {
+  return enUs[`${key}.new`] ?? enUs[key];
+}
+
+/**
  * Resolves an item's display name from the en_us lang map, trying the item
  * key first, then the block key, then falling back to a title-cased id.
  */
 export function getItemName(itemId: string, enUs: Record<string, string>): string {
   return (
-    enUs[`item.minecraft.${itemId}`] ?? enUs[`block.minecraft.${itemId}`] ?? titleCaseFromId(itemId)
+    resolveLangKey(`item.minecraft.${itemId}`, enUs) ??
+    resolveLangKey(`block.minecraft.${itemId}`, enUs) ??
+    titleCaseFromId(itemId)
   );
 }

--- a/scripts/lib/patterned-banner.ts
+++ b/scripts/lib/patterned-banner.ts
@@ -1,4 +1,5 @@
 import { tagMembers } from "./item-stats.ts";
+import { resolveLangKey } from "./lang.ts";
 import { titleCaseFromId } from "./strings.ts";
 import type { RawBannerPatternRegistry, RawTagsData } from "./types.ts";
 
@@ -82,7 +83,8 @@ export function derivePatternedBanners(
     if (!textureExists(patternTextureRef)) continue;
 
     const name =
-      enUs[`${registryEntry.translation_key}.black`] ?? `Black ${titleCaseFromId(patternId)}`;
+      resolveLangKey(`${registryEntry.translation_key}.black`, enUs) ??
+      `Black ${titleCaseFromId(patternId)}`;
 
     entries.push({
       itemId: `patterned_banner_${patternId}`,

--- a/src/data/generated/items.json
+++ b/src/data/generated/items.json
@@ -2811,7 +2811,7 @@
       "type": "flat"
     },
     "id": "bolt_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Bolt Armor Trim",
     "slug": "bolt-armor-trim-smithing-template"
   },
   "bone": {
@@ -4552,7 +4552,7 @@
       "type": "flat"
     },
     "id": "coast_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Coast Armor Trim",
     "slug": "coast-armor-trim-smithing-template"
   },
   "cobbled_deepslate": {
@@ -5982,7 +5982,7 @@
       "type": "flat"
     },
     "id": "creeper_banner_pattern",
-    "name": "Banner Pattern",
+    "name": "Creeper Charge Banner Pattern",
     "slug": "creeper-banner-pattern"
   },
   "creeper_head": {
@@ -8318,7 +8318,7 @@
       "type": "flat"
     },
     "id": "dune_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Dune Armor Trim",
     "slug": "dune-armor-trim-smithing-template"
   },
   "echo_shard": {
@@ -9505,7 +9505,7 @@
       "type": "flat"
     },
     "id": "eye_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Eye Armor Trim",
     "slug": "eye-armor-trim-smithing-template"
   },
   "feather": {
@@ -9614,7 +9614,7 @@
       "type": "flat"
     },
     "id": "flow_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Flow Armor Trim",
     "slug": "flow-armor-trim-smithing-template"
   },
   "flower_banner_pattern": {
@@ -9623,7 +9623,7 @@
       "type": "flat"
     },
     "id": "flower_banner_pattern",
-    "name": "Banner Pattern",
+    "name": "Flower Charge Banner Pattern",
     "slug": "flower-banner-pattern"
   },
   "flower_pot": {
@@ -11351,7 +11351,7 @@
       "type": "flat"
     },
     "id": "host_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Host Armor Trim",
     "slug": "host-armor-trim-smithing-template"
   },
   "ice": {
@@ -14738,7 +14738,7 @@
       "type": "flat"
     },
     "id": "mojang_banner_pattern",
-    "name": "Banner Pattern",
+    "name": "Thing Banner Pattern",
     "slug": "mojang-banner-pattern"
   },
   "moss_block": {
@@ -15126,7 +15126,7 @@
       "type": "flat"
     },
     "id": "netherite_upgrade_smithing_template",
-    "name": "Smithing Template",
+    "name": "Netherite Upgrade",
     "slug": "netherite-upgrade-smithing-template"
   },
   "netherrack": {
@@ -26818,7 +26818,7 @@
       "type": "flat"
     },
     "id": "raiser_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Raiser Armor Trim",
     "slug": "raiser-armor-trim-smithing-template"
   },
   "raw_copper": {
@@ -27494,7 +27494,7 @@
       "type": "flat"
     },
     "id": "rib_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Rib Armor Trim",
     "slug": "rib-armor-trim-smithing-template"
   },
   "rose_bush": {
@@ -28230,7 +28230,7 @@
       "type": "flat"
     },
     "id": "sentry_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Sentry Armor Trim",
     "slug": "sentry-armor-trim-smithing-template"
   },
   "shaper_armor_trim_smithing_template": {
@@ -28239,7 +28239,7 @@
       "type": "flat"
     },
     "id": "shaper_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Shaper Armor Trim",
     "slug": "shaper-armor-trim-smithing-template"
   },
   "shears": {
@@ -28337,7 +28337,7 @@
       "type": "flat"
     },
     "id": "silence_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Silence Armor Trim",
     "slug": "silence-armor-trim-smithing-template"
   },
   "skull_banner_pattern": {
@@ -28346,7 +28346,7 @@
       "type": "flat"
     },
     "id": "skull_banner_pattern",
-    "name": "Banner Pattern",
+    "name": "Skull Charge Banner Pattern",
     "slug": "skull-banner-pattern"
   },
   "slime_ball": {
@@ -28641,7 +28641,7 @@
       "type": "flat"
     },
     "id": "snout_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Snout Armor Trim",
     "slug": "snout-armor-trim-smithing-template"
   },
   "snow": {
@@ -28817,7 +28817,7 @@
       "type": "flat"
     },
     "id": "spire_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Spire Armor Trim",
     "slug": "spire-armor-trim-smithing-template"
   },
   "spruce_boat": {
@@ -29937,7 +29937,7 @@
       "type": "flat"
     },
     "id": "tide_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Tide Armor Trim",
     "slug": "tide-armor-trim-smithing-template"
   },
   "tinted_glass": {
@@ -30120,7 +30120,7 @@
       "type": "flat"
     },
     "id": "vex_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Vex Armor Trim",
     "slug": "vex-armor-trim-smithing-template"
   },
   "vine": {
@@ -30138,7 +30138,7 @@
       "type": "flat"
     },
     "id": "ward_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Ward Armor Trim",
     "slug": "ward-armor-trim-smithing-template"
   },
   "warped_button": {
@@ -33876,7 +33876,7 @@
       "type": "flat"
     },
     "id": "wayfinder_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Wayfinder Armor Trim",
     "slug": "wayfinder-armor-trim-smithing-template"
   },
   "weathered_chiseled_copper": {
@@ -35100,7 +35100,7 @@
       "type": "flat"
     },
     "id": "wild_armor_trim_smithing_template",
-    "name": "Smithing Template",
+    "name": "Wild Armor Trim",
     "slug": "wild-armor-trim-smithing-template"
   },
   "wildflowers": {

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { getItemName } from "../scripts/lib/lang.ts";
+import { getItemName, resolveLangKey } from "../scripts/lib/lang.ts";
+
+describe("resolveLangKey", () => {
+  it("prefers the <key>.new variant when present", () => {
+    const enUs = { "item.minecraft.foo": "Old Name", "item.minecraft.foo.new": "New Name" };
+    expect(resolveLangKey("item.minecraft.foo", enUs)).toBe("New Name");
+  });
+
+  it("falls back to the base key when no .new variant exists", () => {
+    const enUs = { "item.minecraft.foo": "Old Name" };
+    expect(resolveLangKey("item.minecraft.foo", enUs)).toBe("Old Name");
+  });
+
+  it("returns undefined when neither the base key nor the .new key exists", () => {
+    expect(resolveLangKey("item.minecraft.foo", {})).toBeUndefined();
+  });
+});
 
 describe("getItemName", () => {
   it("prefers the item.minecraft.<id> key", () => {
@@ -14,5 +30,21 @@ describe("getItemName", () => {
 
   it("falls back to a title-cased id when neither lang key exists", () => {
     expect(getItemName("some_unknown_item", {})).toBe("Some Unknown Item");
+  });
+
+  it("prefers item.minecraft.<id>.new over the plain item key -- e.g. smithing template renames", () => {
+    const enUs = {
+      "item.minecraft.netherite_upgrade_smithing_template": "Smithing Template",
+      "item.minecraft.netherite_upgrade_smithing_template.new": "Netherite Upgrade",
+    };
+    expect(getItemName("netherite_upgrade_smithing_template", enUs)).toBe("Netherite Upgrade");
+  });
+
+  it("prefers block.minecraft.<id>.new over the plain block key when no item key exists", () => {
+    const enUs = {
+      "block.minecraft.oak_log": "Oak Log",
+      "block.minecraft.oak_log.new": "Oak Log Renamed",
+    };
+    expect(getItemName("oak_log", enUs)).toBe("Oak Log Renamed");
   });
 });

--- a/tests/patterned-banner.test.ts
+++ b/tests/patterned-banner.test.ts
@@ -94,6 +94,21 @@ describe("derivePatternedBanners", () => {
     expect(unnamed?.name).toBe("Black Unnamed");
   });
 
+  it("prefers a <translation_key>.black.new rename over the plain .black key", () => {
+    const renamedEnUs = {
+      ...enUs,
+      "block.minecraft.banner.creeper.black.new": "Creeper Charge Renamed",
+    };
+    const entries = derivePatternedBanners(
+      bannerPatternsRaw,
+      bannerPatternTagsRaw,
+      renamedEnUs,
+      textureExists,
+    );
+    const creeper = entries.find((e) => e.patternId === "creeper");
+    expect(creeper?.name).toBe("Creeper Charge Renamed");
+  });
+
   it("returns entries sorted by pattern id", () => {
     const entries = derivePatternedBanners(
       bannerPatternsRaw,


### PR DESCRIPTION
## Summary

Mojang ships renamed display names as `<key>.new` lang entries; the pipeline used the plain key, leaving 23 items with stale names (19 smithing templates showing "Smithing Template", 4 banner patterns showing "Banner Pattern").

- `scripts/lib/lang.ts`: new `resolveLangKey(key, enUs)` returns `enUs[`${key}.new`] ?? enUs[key]`; `getItemName()` uses it for both item and block key lookups
- `scripts/lib/patterned-banner.ts`: the only other direct lang lookup in the pipeline goes through the same helper (no-op on current pin, future-proofing)
- Regenerated `src/data/generated/items.json` — exactly 23 `name` fields changed, nothing else moved
- Tests: 3 new `resolveLangKey` cases, 2 `getItemName` `.new`-preference cases, 1 patterned-banner rename case

The rule is fully data-driven: future `.new` renames flow through on the next data bump with zero code changes.

## Verification

format / type-check / lint / test (266/266) / parse / validate (online + offline) / build (1163 pages) — all green, JS bundle unaffected.

https://claude.ai/code/session_013ga8yb2vDELdU9x9zZPDtA