### PR TITLE
fix: demote self-referential special recipes below the primary tab row

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -93,6 +93,7 @@ type Recipe = {
   ingredients?: Ingredient[];
   // special only:
   note?: string; // curated human explanation
+  vanillaType?: string; // raw vanilla recipe type id, e.g. "minecraft:crafting_special_bannerduplicate" -- see src/utils/self-referential-specials.ts
 };
 ```
 
@@ -225,6 +226,17 @@ turning the recipe page into a stat sheet. Rendered as HUD-style icon pips
 - Multi-option ingredients (tag or array): cycle through variants on a timer
   (like the Minecraft wiki), with the tag label shown (e.g. "Any Planks").
   Cycling is progressive enhancement; first variant renders statically.
+- **Self-referential specials** (banner duplicate, book cloning, firework
+  star fade, map extending, item repair, shield decoration, leather/wolf
+  armor dye): modify an existing item rather than craft a new one, so they
+  don't render as an equal variant tab alongside the real craft recipe.
+  Classified by an explicit allowlist of vanilla type ids, keyed on the
+  `vanillaType` field (see "Generated data contract" above) —
+  `src/utils/self-referential-specials.ts`. Demoted siblings render in a
+  visually secondary strip below the primary tab row (`RecipeVariants.astro`'s
+  `secondary` prop) instead of an equal tab; an unrecognized vanilla type id
+  (including any a future version bump introduces) fails open to the
+  current equal-tab behavior.
 
 ## Workflows
 

--- a/scripts/lib/recipes.ts
+++ b/scripts/lib/recipes.ts
@@ -121,6 +121,9 @@ export function transformRecipe(
       // vendored data (it acts on two arbitrary matching-type items).
       ...(raw.result ? { result: toResult(raw.result) } : {}),
       note: SPECIAL_NOTES[raw.type],
+      // Raw vanilla type id, kept alongside the coarse "special" bucket above
+      // -- see generated-schema.ts's recipeSchema for why.
+      vanillaType: raw.type,
     };
   }
 

--- a/src/components/RecipePage.astro
+++ b/src/components/RecipePage.astro
@@ -17,6 +17,7 @@ import {
   type SiblingRecipe,
   type VariantGroup,
 } from '../utils/recipe-groups';
+import { isSelfReferentialSpecial } from '../utils/self-referential-specials';
 import { ingredientOption, type IngredientOption } from '../utils/tag-label';
 import { withBase } from '../utils/with-base';
 import type { ItemData, RecipeData } from '../content.config';
@@ -62,13 +63,43 @@ const {
 const resultItem = recipe.result ? itemsMap.get(recipe.result.id) : undefined;
 const getItemName = (id: string) => itemsMap.get(id)?.name ?? id;
 
-const variants = siblings.map((sibling) => ({
+const toVariant = (sibling: SiblingRecipe) => ({
   recipeId: sibling.recipeId,
   label: sibling.label,
   iconItem:
     (sibling.iconItemId ? itemsMap.get(sibling.iconItemId) : undefined) ?? resultItem ?? null,
   href: withBase(recipePath(itemSlug, canonicalId, sibling.recipeId, sibling.slug)),
-}));
+});
+
+// Self-referential specials (banner duplicate, shield decoration, ...)
+// modify an existing item rather than craft a new one -- demoted to a
+// secondary strip below the primary tab row instead of an equal tab (see
+// src/utils/self-referential-specials.ts). Every other sibling, including
+// any special type this repo hasn't classified, stays in the primary row --
+// unchanged from current behavior. Only demotes when at least one *other*
+// sibling stays primary -- e.g. written_book's sole recipe is bookcloning
+// itself (no craft recipe exists to demote it "below"), so with nothing
+// left to demote below, it stays undivided, exactly like any other
+// singleton (no tabs at all).
+const hasPrimarySibling = siblings.some(
+  (sibling) => !isSelfReferentialSpecial(sibling.vanillaType),
+);
+
+const primarySiblings = hasPrimarySibling
+  ? siblings.filter((sibling) => !isSelfReferentialSpecial(sibling.vanillaType))
+  : siblings;
+const secondarySiblings = hasPrimarySibling
+  ? siblings.filter((sibling) => isSelfReferentialSpecial(sibling.vanillaType))
+  : [];
+
+const variants = primarySiblings.map(toVariant);
+const secondaryVariants = secondarySiblings.map(toVariant);
+// A lone primary variant still renders as a (single-chip) tab row whenever a
+// secondary strip sits below it, so a demoted recipe's own page always has a
+// link back to the real craft recipe -- without a secondary strip, a lone
+// primary variant is just an ordinary singleton and stays hidden, unchanged
+// from current behavior.
+const showPrimaryVariants = variants.length > 1 || secondaryVariants.length > 0;
 
 // The outer color/material tab bar, when this item is part of a collapsed
 // VariantGroup -- result-first icons (each tab shows that variant's own
@@ -192,7 +223,18 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
       )
     }
 
-    {siblings.length > 1 && <RecipeVariants siblings={variants} currentId={recipe.id} />}
+    {showPrimaryVariants && <RecipeVariants siblings={variants} currentId={recipe.id} />}
+
+    {
+      secondaryVariants.length > 0 && (
+        <RecipeVariants
+          siblings={secondaryVariants}
+          currentId={recipe.id}
+          heading="Modifies an existing item"
+          secondary
+        />
+      )
+    }
 
     {
       hasGrid ? (

--- a/src/components/RecipeVariants.astro
+++ b/src/components/RecipeVariants.astro
@@ -12,12 +12,20 @@ interface Variant {
 interface Props {
   siblings: Variant[];
   currentId: string;
+  /** Small label rendered above the strip -- present only for the demoted secondary strip (see `secondary` below); the primary tab row stays unlabeled, matching current behavior. */
+  heading?: string;
+  /** Visually de-emphasized strip for recipes that modify an existing item rather than craft a new one (self-referential specials -- see src/utils/self-referential-specials.ts), rendered below the primary variant tabs instead of as an equal tab. */
+  secondary?: boolean;
 }
 
-const { siblings, currentId } = Astro.props;
+const { siblings, currentId, heading, secondary = false } = Astro.props;
 ---
 
-<nav class="recipe-variants" aria-label="Other recipes for this item">
+<nav
+  class:list={['recipe-variants', { 'recipe-variants--secondary': secondary }]}
+  aria-label={heading ?? 'Other recipes for this item'}
+>
+  {heading && <h2 class="recipe-variants__title">{heading}</h2>}
   <ul class="recipe-variants__list">
     {
       siblings.map((sibling) => {
@@ -52,6 +60,15 @@ const { siblings, currentId } = Astro.props;
     margin-bottom: var(--space-6);
   }
 
+  .recipe-variants__title {
+    margin: 0 0 var(--space-2);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-muted);
+  }
+
   .recipe-variants__list {
     display: flex;
     flex-wrap: wrap;
@@ -70,5 +87,25 @@ const { siblings, currentId } = Astro.props;
     width: 1.25rem;
     flex-shrink: 0;
     image-rendering: pixelated;
+  }
+
+  /* Demoted self-referential specials (banner duplicate, shield decoration,
+     ...) -- same chip shape as the primary tab row, just visually quieter
+     and set apart by a divider, so it reads as a secondary action rather
+     than an equal alternative. */
+  .recipe-variants--secondary {
+    margin-top: calc(-1 * var(--space-3));
+    padding-top: var(--space-4);
+    border-top: var(--divider-border);
+    box-shadow: var(--divider-shadow-top);
+  }
+
+  .recipe-variants--secondary .recipe-variant {
+    font-size: 0.75rem;
+    opacity: 0.8;
+  }
+
+  .recipe-variants--secondary .recipe-variant__icon {
+    width: 1rem;
   }
 </style>

--- a/src/data/generated-schema.ts
+++ b/src/data/generated-schema.ts
@@ -59,6 +59,15 @@ export const recipeSchema = z.object({
   ingredients: z.array(ingredientSchema).optional(),
   // special only
   note: z.string().optional(),
+  // special only -- the raw vanilla recipe type id (e.g.
+  // "minecraft:crafting_special_bannerduplicate"), preserved because the
+  // coarse `type: "special"` bucket above collapses ~11 distinct vanilla
+  // types into one value. shaped/shapeless/transmute don't need this: each
+  // already maps 1:1 to a single vanilla type via `type` itself. Consumed by
+  // src/utils/self-referential-specials.ts to demote self-referential
+  // specials (banner duplicate, shield decoration, ...) below the primary
+  // variant tabs -- see scripts/lib/recipes.ts's transformRecipe.
+  vanillaType: z.string().optional(),
 });
 
 /**

--- a/src/data/generated/recipes.json
+++ b/src/data/generated/recipes.json
@@ -1638,7 +1638,8 @@
       "id": "black_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "black_bed": {
     "category": "misc",
@@ -2204,7 +2205,8 @@
       "id": "blue_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "blue_bed": {
     "category": "misc",
@@ -2810,7 +2812,8 @@
       "id": "written_book"
     },
     "slug": "book-cloning",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bookcloning"
   },
   "bookshelf": {
     "category": "building",
@@ -3115,7 +3118,8 @@
       "id": "brown_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "brown_bed": {
     "category": "misc",
@@ -6480,7 +6484,8 @@
       "id": "cyan_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "cyan_bed": {
     "category": "misc",
@@ -7387,7 +7392,8 @@
       "id": "decorated_pot"
     },
     "slug": "default",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_decorated_pot"
   },
   "decorated_pot_simple": {
     "category": "misc",
@@ -11179,7 +11185,8 @@
       "id": "firework_rocket"
     },
     "slug": "default",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_firework_rocket"
   },
   "firework_rocket_simple": {
     "category": "misc",
@@ -11214,7 +11221,8 @@
       "id": "firework_star"
     },
     "slug": "default",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_firework_star"
   },
   "firework_star_fade": {
     "category": "misc",
@@ -11226,7 +11234,8 @@
       "id": "firework_star"
     },
     "slug": "fade",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_firework_star_fade"
   },
   "fishing_rod": {
     "category": "equipment",
@@ -12123,7 +12132,8 @@
       "id": "gray_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "gray_bed": {
     "category": "misc",
@@ -12577,7 +12587,8 @@
       "id": "green_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "green_bed": {
     "category": "misc",
@@ -14311,7 +14322,8 @@
       "id": "leather_boots"
     },
     "slug": "dyed",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_dye"
   },
   "leather_chestplate": {
     "category": "equipment",
@@ -14347,7 +14359,8 @@
       "id": "leather_chestplate"
     },
     "slug": "dyed",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_dye"
   },
   "leather_helmet": {
     "category": "equipment",
@@ -14382,7 +14395,8 @@
       "id": "leather_helmet"
     },
     "slug": "dyed",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_dye"
   },
   "leather_horse_armor": {
     "category": "misc",
@@ -14418,7 +14432,8 @@
       "id": "leather_horse_armor"
     },
     "slug": "dyed",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_dye"
   },
   "leather_leggings": {
     "category": "equipment",
@@ -14454,7 +14469,8 @@
       "id": "leather_leggings"
     },
     "slug": "dyed",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_dye"
   },
   "lectern": {
     "category": "redstone",
@@ -14562,7 +14578,8 @@
       "id": "light_blue_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "light_blue_bed": {
     "category": "misc",
@@ -15016,7 +15033,8 @@
       "id": "light_gray_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "light_gray_bed": {
     "category": "misc",
@@ -15581,7 +15599,8 @@
       "id": "lime_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "lime_bed": {
     "category": "misc",
@@ -16109,7 +16128,8 @@
       "id": "magenta_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "magenta_bed": {
     "category": "misc",
@@ -17078,7 +17098,8 @@
       "id": "filled_map"
     },
     "slug": "map-extending",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_mapextending"
   },
   "melon": {
     "category": "building",
@@ -18457,7 +18478,8 @@
       "id": "orange_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "orange_bed": {
     "category": "misc",
@@ -20174,7 +20196,8 @@
       "id": "pink_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "pink_bed": {
     "category": "misc",
@@ -21852,7 +21875,8 @@
       "id": "purple_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "purple_bed": {
     "category": "misc",
@@ -22780,7 +22804,8 @@
       "id": "red_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "red_bed": {
     "category": "misc",
@@ -24042,7 +24067,8 @@
       "id": "shield"
     },
     "slug": "decoration",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_shielddecoration"
   },
   "shulker_box": {
     "category": "misc",
@@ -26720,7 +26746,8 @@
       "id": "tipped_arrow"
     },
     "slug": "default",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_imbue"
   },
   "tnt": {
     "category": "redstone",
@@ -29733,7 +29760,8 @@
       "id": "white_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "white_bed": {
     "category": "misc",
@@ -30250,7 +30278,8 @@
       "id": "wolf_armor"
     },
     "slug": "dyed",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_dye"
   },
   "wooden_axe": {
     "category": "equipment",
@@ -30559,7 +30588,8 @@
       "id": "yellow_banner"
     },
     "slug": "duplicate",
-    "type": "special"
+    "type": "special",
+    "vanillaType": "minecraft:crafting_special_bannerduplicate"
   },
   "yellow_bed": {
     "category": "misc",

--- a/src/utils/recipe-groups.ts
+++ b/src/utils/recipe-groups.ts
@@ -96,6 +96,8 @@ function stripOxidationPrefixes(resultId: string): string {
 export interface SiblingRecipe {
   recipeId: string;
   type: RecipeData["type"];
+  /** Raw vanilla recipe type id, only set when `type === "special"` -- see src/utils/self-referential-specials.ts. */
+  vanillaType: string | undefined;
   /** e.g. "from Bone", or a truncated note for special recipes. Null for singletons. */
   label: string | null;
   /** The distinguishing ingredient's item id. Null for singletons and special recipes. */
@@ -227,6 +229,7 @@ export function groupRecipes(
         return {
           recipeId: recipe.id,
           type: recipe.type,
+          vanillaType: recipe.vanillaType,
           label: null,
           iconItemId: null,
           ingredientItemIds,
@@ -238,6 +241,7 @@ export function groupRecipes(
         return {
           recipeId: recipe.id,
           type: recipe.type,
+          vanillaType: recipe.vanillaType,
           label: recipe.note ? truncateNote(recipe.note) : null,
           iconItemId: null,
           ingredientItemIds,
@@ -251,6 +255,7 @@ export function groupRecipes(
       return {
         recipeId: recipe.id,
         type: recipe.type,
+        vanillaType: recipe.vanillaType,
         label: `from ${ingredientLabel(distinguishing, getItemName)}`,
         iconItemId: distinguishing.items[0],
         ingredientItemIds,

--- a/src/utils/self-referential-specials.ts
+++ b/src/utils/self-referential-specials.ts
@@ -1,0 +1,51 @@
+/**
+ * Vanilla `crafting_special_*` (and `crafting_dye`) recipe types that modify
+ * an EXISTING item of the same kind rather than craft a genuinely new one --
+ * e.g. duplicating a banner's pattern onto a second blank banner, or
+ * re-dyeing a leather armor piece that's already craftable from raw
+ * materials. Ground truth (vendor/mcmeta-summary/data/recipe/data.json, pin
+ * 26.2): every id below has an ingredient field (`banner`, `target`, `map`,
+ * `source`) whose value is the *same* item id as the recipe's own `result`
+ * -- the deterministic signal that it modifies rather than creates. Recipe
+ * types NOT in this set (`crafting_special_firework_rocket`,
+ * `crafting_special_firework_star`, `crafting_decorated_pot`,
+ * `crafting_imbue`) all produce a genuinely different item than any of
+ * their own ingredients, so they stay in the primary tab row.
+ *
+ * Keyed on the vanilla type id (not per-recipe), so every color/material
+ * instance of a type (16 banner colors, 6 leather-dye targets, ...)
+ * classifies uniformly, and a future mcmeta version bump needs zero code
+ * changes to keep classifying correctly.
+ */
+const SELF_REFERENTIAL_SPECIAL_TYPES: ReadonlySet<string> = new Set([
+  // Duplicates a banner's pattern onto a second banner of the same color.
+  "minecraft:crafting_special_bannerduplicate",
+  // Copies a written book's contents onto another book and quill. Currently
+  // has no visible effect (written_book has no other recipe to sit beside),
+  // included for correctness should that ever change.
+  "minecraft:crafting_special_bookcloning",
+  // Adds a fade-to-color effect to an existing firework star.
+  "minecraft:crafting_special_firework_star_fade",
+  // Extends an existing filled map to the next zoom level.
+  "minecraft:crafting_special_mapextending",
+  // Repairs two damaged items of the same type. Excluded from generated
+  // data entirely today -- it carries no `result` in vendored data, and
+  // scripts/lib/generate.ts skips any resultless recipe -- included here so
+  // this allowlist stays correct if a future data bump ever adds one.
+  "minecraft:crafting_special_repairitem",
+  // Applies a banner's pattern onto an existing shield.
+  "minecraft:crafting_special_shielddecoration",
+  // Re-dyes an existing leather armor piece or wolf armor with a new color.
+  "minecraft:crafting_dye",
+]);
+
+/**
+ * True when `vanillaType` names a self-referential special recipe (see
+ * SELF_REFERENTIAL_SPECIAL_TYPES above). `undefined` -- every non-special
+ * recipe, and any special recipe type this repo hasn't classified,
+ * including ones a future version bump introduces -- fails open to `false`,
+ * i.e. the current equal-tab behavior.
+ */
+export function isSelfReferentialSpecial(vanillaType: string | undefined): boolean {
+  return vanillaType !== undefined && SELF_REFERENTIAL_SPECIAL_TYPES.has(vanillaType);
+}

--- a/tests/recipe-groups.test.ts
+++ b/tests/recipe-groups.test.ts
@@ -121,6 +121,7 @@ describe("groupRecipes", () => {
         family: { collection: "families", id: "banners" },
         result: { id: "black_banner", count: 1 },
         note: "Combine a banner with a matching blank banner to duplicate its pattern.",
+        vanillaType: "minecraft:crafting_special_bannerduplicate",
       }),
     ];
 
@@ -131,8 +132,16 @@ describe("groupRecipes", () => {
     expect(special).toMatchObject({
       label: "Combine a banner with a matching blank …",
       iconItemId: null,
+      // `vanillaType` survives onto the sibling -- consumed by
+      // src/utils/self-referential-specials.ts (via RecipePage.astro) to
+      // demote this sibling below the primary variant tabs.
+      vanillaType: "minecraft:crafting_special_bannerduplicate",
     });
-    expect(shaped).toMatchObject({ label: "from Black wool", iconItemId: "black_wool" });
+    expect(shaped).toMatchObject({
+      label: "from Black wool",
+      iconItemId: "black_wool",
+      vanillaType: undefined,
+    });
   });
 
   it("falls back to each sibling's first ingredient when they share nothing", () => {

--- a/tests/recipes.test.ts
+++ b/tests/recipes.test.ts
@@ -108,6 +108,10 @@ describe("transformRecipe — crafting_transmute", () => {
 
     const recipe = transformRecipe("black_bundle", raw, tags);
     expect(recipe?.type).toBe("transmute");
+    // Only "special" carries `vanillaType` -- shaped/shapeless/transmute each
+    // already map 1:1 to a single vanilla type via `type` itself (see
+    // generated-schema.ts's recipeSchema).
+    expect(recipe?.vanillaType).toBeUndefined();
     expect(recipe?.ingredients).toEqual([
       { items: ["oak_log", "oak_wood", "stripped_oak_log", "stripped_oak_wood"], tag: "oak_logs" },
       { items: ["black_dye"] },
@@ -129,6 +133,10 @@ describe("transformRecipe — special", () => {
     expect(recipe?.ingredients).toBeUndefined();
     expect(recipe?.key).toBeUndefined();
     expect(recipe?.result).toEqual({ id: "black_banner", count: 1 });
+    // The raw vanilla type id survives the transform (see generated-schema.ts's
+    // recipeSchema) -- consumed by src/utils/self-referential-specials.ts to
+    // demote self-referential specials below the primary variant tabs.
+    expect(recipe?.vanillaType).toBe("minecraft:crafting_special_bannerduplicate");
   });
 
   it("omits result entirely for crafting_special_repairitem (no result in vendored data)", () => {
@@ -137,6 +145,7 @@ describe("transformRecipe — special", () => {
     expect(recipe?.type).toBe("special");
     expect(recipe?.result).toBeUndefined();
     expect(recipe?.note).toBeTruthy();
+    expect(recipe?.vanillaType).toBe("minecraft:crafting_special_repairitem");
   });
 
   it("returns undefined for out-of-scope recipe types", () => {

--- a/tests/self-referential-specials.test.ts
+++ b/tests/self-referential-specials.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isSelfReferentialSpecial } from "../src/utils/self-referential-specials";
+
+describe("isSelfReferentialSpecial", () => {
+  it("classifies every self-referential special type id as true", () => {
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_bannerduplicate")).toBe(true);
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_bookcloning")).toBe(true);
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_firework_star_fade")).toBe(true);
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_mapextending")).toBe(true);
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_repairitem")).toBe(true);
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_shielddecoration")).toBe(true);
+    expect(isSelfReferentialSpecial("minecraft:crafting_dye")).toBe(true);
+  });
+
+  it("keeps genuine 'craft a new item' specials classified as false", () => {
+    // Each of these produces an item that's absent from its own ingredient
+    // list -- ground truth verified against vendor/mcmeta-summary/data/recipe
+    // (see src/utils/self-referential-specials.ts's doc comment).
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_firework_rocket")).toBe(false);
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_firework_star")).toBe(false);
+    expect(isSelfReferentialSpecial("minecraft:crafting_decorated_pot")).toBe(false);
+    expect(isSelfReferentialSpecial("minecraft:crafting_imbue")).toBe(false);
+  });
+
+  it("fails open (false) for undefined -- every non-special recipe", () => {
+    expect(isSelfReferentialSpecial(undefined)).toBe(false);
+  });
+
+  it("fails open (false) for an unrecognized vanilla type id -- e.g. a future version bump", () => {
+    expect(isSelfReferentialSpecial("minecraft:crafting_special_some_future_type")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Vanilla `crafting_special_*` recipes that merely modify an existing item of the same kind (banner duplicate, book cloning, firework star fade, map extending, shield decoration, leather/wolf armor dye) rendered as equal variant tabs alongside the real craft recipe.

- `scripts/lib/recipes.ts`: persists `vanillaType` onto every special recipe in generated data — the deterministic classification signal
- `src/utils/self-referential-specials.ts` (new): grounded, commented allowlist of self-referential vanilla type ids (each verified against vendored data: an ingredient equals the recipe's own result). Fails open — unknown/absent types keep current behavior
- `src/components/RecipePage.astro`: partitions siblings into primary/secondary; demotion only fires when a real primary sibling exists (prevents an empty primary nav on pages like written book, whose sole recipe is self-referential)
- `src/components/RecipeVariants.astro`: new `heading`/`secondary` props render the demoted strip quieter (smaller chips, muted "Modifies an existing item" heading), reusing the existing chip system

50 recipe pages gain the secondary strip (16 banner colors, shield, firework star, filled map, 6 dye-able armor items). Confirmed NOT demoted: firework rocket/star, decorated pot, imbue — they produce items absent from their own ingredients.

## Verification

format / type-check / lint / test (264/264, incl. new suites) / parse (no count change) / validate (online + offline) / build (1163 pages) — all green, JS gzip unchanged, zero new JS.

https://claude.ai/code/session_013ga8yb2vDELdU9x9zZPDtA