### PR TITLE
feat: tag-driven variant collapse, scalable variant picker, lonely-section fix

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -88,6 +88,7 @@ type Recipe = {
   family: string; // derived browse taxonomy, e.g. "Slabs" — see scripts/lib/family.ts
   slug: string; // URL-safe /recipe/{item}/{slug}/ segment, unique within its result-item group — see scripts/lib/recipe-slug.ts
   group?: string; // vanilla group, e.g. "planks", "wooden_door"
+  shapeTag?: string; // shape-family collapse key from vanilla item tags, e.g. "slabs" — see scripts/lib/shape-tag.ts
   result: { id: string; count: number };
   // shaped only — placement matters:
   pattern?: string[]; // e.g. ["X", "#"]; keys index into `key`

--- a/scripts/lib/generate.ts
+++ b/scripts/lib/generate.ts
@@ -30,6 +30,7 @@ import type { IconCandidate } from "./model.ts";
 import { derivePatternedBanners, PATTERNED_BANNER_GROUP } from "./patterned-banner.ts";
 import { deriveRecipeSlugSource } from "./recipe-slug.ts";
 import { collectRecipeItemIds, transformRecipe } from "./recipes.ts";
+import { deriveShapeTag } from "./shape-tag.ts";
 import {
   SHIELD_ATLAS_REF,
   SHIELD_TEMPLATE_TEXTURE_REF,
@@ -237,6 +238,7 @@ export function generate(input: GenerateInput): GenerateOutput {
       itemTagIndex,
     );
     if (derivedFamily.usedFallback) fallbackFamilyItems.push(resultId);
+    const shapeTag = deriveShapeTag(resultId, itemTagIndex);
 
     if (!(derivedFamily.id in familiesUsed)) {
       const categoryId = FAMILY_CATEGORY[derivedFamily.id];
@@ -259,7 +261,12 @@ export function generate(input: GenerateInput): GenerateOutput {
     }
 
     const slug = slugify(deriveRecipeSlugSource(id, resultId));
-    const recipe = { ...transformed, family: derivedFamily.id, slug };
+    const recipe = {
+      ...transformed,
+      family: derivedFamily.id,
+      slug,
+      ...(shapeTag ? { shapeTag } : {}),
+    };
     recipes[id] = recipe;
     counts[recipe.type] += 1;
   }

--- a/scripts/lib/shape-tag.ts
+++ b/scripts/lib/shape-tag.ts
@@ -1,0 +1,78 @@
+import type { ItemTagIndex } from "./family.ts";
+
+/**
+ * Vanilla item tags that unify every material Mojang ships for one
+ * interchangeable shape -- e.g. `#minecraft:slabs` holds oak_slab,
+ * stone_slab, AND cut_copper_slab (plus all 8 of its oxidation/waxing
+ * tiers), all as siblings of the same "slab" shape. Used by
+ * src/utils/recipe-groups.ts to collapse a shape's material variants into
+ * one tabbed catalog card, e.g. one "Slabs" card instead of 49 (see that
+ * file's groupRecipes).
+ *
+ * Deliberately its own curated list, NOT a reuse of
+ * scripts/lib/family.ts's TAG_FAMILY_PRIORITY: that list serves the
+ * coarser top-level browse taxonomy and deliberately includes tags like
+ * "logs"/"copper"/"pickaxes" that group related but visually/functionally
+ * DIFFERENT items -- collapsing those into one tabbed card the way this
+ * list does would be wrong (e.g. the "copper" tag spans cut copper,
+ * copper bulbs, the golem statue, lightning rods, ... -- very much not
+ * "one shape, several materials").
+ *
+ * Every tag here was confirmed against the vendored tag data
+ * (vendor/mcmeta-summary/data/tag/item/data.json) to follow the same
+ * shape: a `#wooden_X` sub-tag (or, for walls, a flat list -- vanilla has
+ * no wooden wall) plus additional non-wood material ids for the identical
+ * shape. Order doesn't currently matter (no item belongs to more than one
+ * of these in the current data) but is kept as an explicit priority list
+ * (first match wins) in case a future item ever legitimately belongs to
+ * two.
+ *
+ * `doors`/`trapdoors`/`fences` are included even though they weren't
+ * called out by name in the original bug report -- each has the exact
+ * same wood-plus-more tag shape as slabs/stairs/walls/buttons (doors:
+ * 12 wood + 8 copper oxidation tiers + iron_door; trapdoors: same shape
+ * as doors; fences: 12 wood + nether_brick_fence), so leaving them out
+ * would be an arbitrary inconsistency in an otherwise general,
+ * data-driven rule. Confirmed against the real data with a systematic
+ * sweep of every `wooden_X` tag, comparing its member count to its bare
+ * `X` counterpart's (see the sweep in this file's PR/commit description) --
+ * this list is exactly the set where that comparison finds extra,
+ * non-wood members.
+ *
+ * Deliberately NOT included: fence_gates/signs/hanging_signs/
+ * wooden_shelves (real vendored tags/groups exist for all four, but every
+ * member is wood-only in the current data -- no non-wood sibling exists to
+ * collapse in, so routing them through this mechanism wouldn't change a
+ * single card's membership today, only its internal key name for no
+ * benefit. Add the relevant tag here the day vanilla ships a non-wood
+ * member of any of those shapes -- e.g. a stone sign). Also NOT included:
+ * pressure plates -- no vendored tag unifies them across materials (only
+ * "wooden_pressure_plates" exists; stone/weighted plates share no tag or
+ * `group` with each other or with wood), so there is no real data signal
+ * to key a "Pressure Plates" collapse off yet.
+ */
+const SHAPE_TAG_IDS = [
+  "slabs",
+  "stairs",
+  "walls",
+  "buttons",
+  "doors",
+  "trapdoors",
+  "fences",
+] as const;
+
+/**
+ * Derives a recipe result's shape-based collapse key from vanilla item
+ * tags (see SHAPE_TAG_IDS), e.g. "cut_copper_slab" -> "slabs". Returns
+ * undefined when the item isn't in any allow-listed shape tag, so callers
+ * fall back to their existing derivation (see
+ * src/utils/recipe-groups.ts's groupRecipes, which prefers this over its
+ * oxidation-prefix and vanilla-`group` derivations -- the most complete
+ * signal, since it's the only one that unifies every material of a shape,
+ * copper included, in one pass).
+ */
+export function deriveShapeTag(itemId: string, itemTagIndex: ItemTagIndex): string | undefined {
+  const tags = itemTagIndex.get(itemId);
+  if (!tags) return undefined;
+  return SHAPE_TAG_IDS.find((tag) => tags.has(tag));
+}

--- a/src/components/RecipeVariants.astro
+++ b/src/components/RecipeVariants.astro
@@ -19,6 +19,19 @@ interface Props {
 }
 
 const { siblings, currentId, heading, secondary = false } = Astro.props;
+
+// Past this many variants, the equal-width chip row (designed for a
+// handful of "from X" ingredient siblings) stops scaling -- a fully tag-
+// collapsed shape like Slabs or Doors can carry 20-60+ material variants
+// (see src/utils/recipe-groups.ts's shapeTag precedence). Past the
+// threshold, switch to a compact icon-only grid instead: same markup and
+// zero extra JS, just denser cells with the label moved to a native
+// `title` tooltip + a visually-hidden accessible name rather than always-
+// visible text (see AGENTS.md's "presentation constant" -- this is a
+// display threshold, not vanilla data, so it lives here as a plain
+// constant rather than in the data pipeline).
+const VARIANT_PICKER_THRESHOLD = 20;
+const isCompact = siblings.length > VARIANT_PICKER_THRESHOLD;
 ---
 
 <nav
@@ -26,7 +39,7 @@ const { siblings, currentId, heading, secondary = false } = Astro.props;
   aria-label={heading ?? 'Other recipes for this item'}
 >
   {heading && <h2 class="recipe-variants__title">{heading}</h2>}
-  <ul class="recipe-variants__list">
+  <ul class:list={['recipe-variants__list', { 'recipe-variants__list--compact': isCompact }]}>
     {
       siblings.map((sibling) => {
         const isCurrent = sibling.recipeId === currentId;
@@ -34,18 +47,39 @@ const { siblings, currentId, heading, secondary = false } = Astro.props;
         return (
           <li>
             {isCurrent ? (
-              <span class="recipe-variant link-chip link-chip--selected" aria-current="page">
+              <span
+                class:list={[
+                  'recipe-variant',
+                  'link-chip',
+                  'link-chip--selected',
+                  { 'recipe-variant--compact': isCompact },
+                ]}
+                aria-current="page"
+                title={isCompact ? label : undefined}
+              >
                 <span class="recipe-variant__icon">
                   <ItemIcon item={sibling.iconItem} />
                 </span>
-                <span class="recipe-variant__label">{label}</span>
+                <span class:list={['recipe-variant__label', { 'visually-hidden': isCompact }]}>
+                  {label}
+                </span>
               </span>
             ) : (
-              <a href={sibling.href} class="recipe-variant link-chip">
+              <a
+                href={sibling.href}
+                class:list={[
+                  'recipe-variant',
+                  'link-chip',
+                  { 'recipe-variant--compact': isCompact },
+                ]}
+                title={isCompact ? label : undefined}
+              >
                 <span class="recipe-variant__icon">
                   <ItemIcon item={sibling.iconItem} />
                 </span>
-                <span class="recipe-variant__label">{label}</span>
+                <span class:list={['recipe-variant__label', { 'visually-hidden': isCompact }]}>
+                  {label}
+                </span>
               </a>
             )}
           </li>
@@ -75,11 +109,27 @@ const { siblings, currentId, heading, secondary = false } = Astro.props;
     gap: var(--space-2);
   }
 
+  /* Compact picker: a dense icon-only grid instead of a wrapping chip row,
+     for a fully tag-collapsed shape's 20-60+ material variants (see
+     VARIANT_PICKER_THRESHOLD above). Mobile-first: minmax(2.5rem, ...)
+     already fits several columns on a narrow screen, growing to more
+     columns on wider viewports for free via auto-fill. */
+  .recipe-variants__list--compact {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(2.5rem, 1fr));
+    gap: var(--space-1);
+  }
+
   .recipe-variant {
     padding: var(--space-2) var(--space-3);
     font-size: 0.8125rem;
     color: var(--color-panel-fg);
     text-transform: capitalize;
+  }
+
+  .recipe-variant--compact {
+    justify-content: center;
+    padding: var(--space-2);
   }
 
   .recipe-variant__icon {

--- a/src/data/generated-schema.ts
+++ b/src/data/generated-schema.ts
@@ -47,6 +47,8 @@ export const recipeSchema = z.object({
   /** URL-safe /recipe/{item}/{slug}/ segment, unique within the recipe's result-item group (see scripts/lib/recipe-slug.ts). */
   slug: z.string(),
   group: z.string().optional(),
+  /** This result item's shape-family collapse key, derived from vanilla item tags (e.g. "slabs") -- see scripts/lib/shape-tag.ts's deriveShapeTag. Absent when the result isn't in any allow-listed shape tag. */
+  shapeTag: z.string().optional(),
   // Vanilla's recipe schema allows a resultless special recipe (e.g.
   // crafting_special_repairitem) -- generate.ts excludes any recipe shaped
   // like that from what's actually emitted, so every recipe here has one in

--- a/src/data/generated/recipes.json
+++ b/src/data/generated/recipes.json
@@ -38,6 +38,7 @@
       "count": 1,
       "id": "acacia_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -86,6 +87,7 @@
       "count": 3,
       "id": "acacia_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -114,6 +116,7 @@
       "count": 3,
       "id": "acacia_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -291,6 +294,7 @@
       "count": 6,
       "id": "acacia_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -315,6 +319,7 @@
       "count": 4,
       "id": "acacia_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -338,6 +343,7 @@
       "count": 2,
       "id": "acacia_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -460,6 +466,7 @@
       "count": 6,
       "id": "andesite_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -483,6 +490,7 @@
       "count": 4,
       "id": "andesite_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -505,6 +513,7 @@
       "count": 6,
       "id": "andesite_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -671,6 +680,7 @@
       "count": 1,
       "id": "bamboo_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -719,6 +729,7 @@
       "count": 3,
       "id": "bamboo_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -747,6 +758,7 @@
       "count": 3,
       "id": "bamboo_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -847,6 +859,7 @@
       "count": 6,
       "id": "bamboo_mosaic_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -870,6 +883,7 @@
       "count": 4,
       "id": "bamboo_mosaic_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -1011,6 +1025,7 @@
       "count": 6,
       "id": "bamboo_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -1035,6 +1050,7 @@
       "count": 4,
       "id": "bamboo_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -1058,6 +1074,7 @@
       "count": 2,
       "id": "bamboo_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -1273,6 +1290,7 @@
       "count": 1,
       "id": "birch_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -1321,6 +1339,7 @@
       "count": 3,
       "id": "birch_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -1349,6 +1368,7 @@
       "count": 3,
       "id": "birch_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -1526,6 +1546,7 @@
       "count": 6,
       "id": "birch_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -1550,6 +1571,7 @@
       "count": 4,
       "id": "birch_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -1573,6 +1595,7 @@
       "count": 2,
       "id": "birch_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -2067,6 +2090,7 @@
       "count": 6,
       "id": "blackstone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -2090,6 +2114,7 @@
       "count": 4,
       "id": "blackstone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -2112,6 +2137,7 @@
       "count": 6,
       "id": "blackstone_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -3009,6 +3035,7 @@
       "count": 6,
       "id": "brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -3032,6 +3059,7 @@
       "count": 4,
       "id": "brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -3054,6 +3082,7 @@
       "count": 6,
       "id": "brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -3895,6 +3924,7 @@
       "count": 1,
       "id": "cherry_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -3943,6 +3973,7 @@
       "count": 3,
       "id": "cherry_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -3971,6 +4002,7 @@
       "count": 3,
       "id": "cherry_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -4148,6 +4180,7 @@
       "count": 6,
       "id": "cherry_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -4172,6 +4205,7 @@
       "count": 4,
       "id": "cherry_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -4195,6 +4229,7 @@
       "count": 2,
       "id": "cherry_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -4635,6 +4670,7 @@
       "count": 6,
       "id": "cinnabar_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -4658,6 +4694,7 @@
       "count": 4,
       "id": "cinnabar_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -4680,6 +4717,7 @@
       "count": 6,
       "id": "cinnabar_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -4723,6 +4761,7 @@
       "count": 6,
       "id": "cinnabar_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -4746,6 +4785,7 @@
       "count": 4,
       "id": "cinnabar_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -4768,6 +4808,7 @@
       "count": 6,
       "id": "cinnabar_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -4940,6 +4981,7 @@
       "count": 6,
       "id": "cobbled_deepslate_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -4963,6 +5005,7 @@
       "count": 4,
       "id": "cobbled_deepslate_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -4985,6 +5028,7 @@
       "count": 6,
       "id": "cobbled_deepslate_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -5006,6 +5050,7 @@
       "count": 6,
       "id": "cobblestone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -5029,6 +5074,7 @@
       "count": 4,
       "id": "cobblestone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -5051,6 +5097,7 @@
       "count": 6,
       "id": "cobblestone_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -5433,6 +5480,7 @@
       "count": 3,
       "id": "copper_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -5811,6 +5859,7 @@
       "count": 1,
       "id": "copper_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -5953,6 +6002,7 @@
       "count": 1,
       "id": "crimson_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -5977,6 +6027,7 @@
       "count": 3,
       "id": "crimson_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -6005,6 +6056,7 @@
       "count": 3,
       "id": "crimson_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -6205,6 +6257,7 @@
       "count": 6,
       "id": "crimson_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -6229,6 +6282,7 @@
       "count": 4,
       "id": "crimson_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -6252,6 +6306,7 @@
       "count": 2,
       "id": "crimson_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -6333,6 +6388,7 @@
       "count": 6,
       "id": "cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -6356,6 +6412,7 @@
       "count": 4,
       "id": "cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -6399,6 +6456,7 @@
       "count": 6,
       "id": "cut_red_sandstone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -6442,6 +6500,7 @@
       "count": 6,
       "id": "cut_sandstone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -6939,6 +6998,7 @@
       "count": 1,
       "id": "dark_oak_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -6987,6 +7047,7 @@
       "count": 3,
       "id": "dark_oak_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -7015,6 +7076,7 @@
       "count": 3,
       "id": "dark_oak_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -7192,6 +7254,7 @@
       "count": 6,
       "id": "dark_oak_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -7216,6 +7279,7 @@
       "count": 4,
       "id": "dark_oak_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -7239,6 +7303,7 @@
       "count": 2,
       "id": "dark_oak_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -7311,6 +7376,7 @@
       "count": 6,
       "id": "dark_prismarine_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -7334,6 +7400,7 @@
       "count": 4,
       "id": "dark_prismarine_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -7436,6 +7503,7 @@
       "count": 6,
       "id": "deepslate_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -7459,6 +7527,7 @@
       "count": 4,
       "id": "deepslate_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -7481,6 +7550,7 @@
       "count": 6,
       "id": "deepslate_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -7524,6 +7594,7 @@
       "count": 6,
       "id": "deepslate_tile_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -7547,6 +7618,7 @@
       "count": 4,
       "id": "deepslate_tile_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -7569,6 +7641,7 @@
       "count": 6,
       "id": "deepslate_tile_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -7977,6 +8050,7 @@
       "count": 6,
       "id": "diorite_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -8000,6 +8074,7 @@
       "count": 4,
       "id": "diorite_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -8022,6 +8097,7 @@
       "count": 6,
       "id": "diorite_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -10795,6 +10871,7 @@
       "count": 6,
       "id": "end_stone_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -10818,6 +10895,7 @@
       "count": 4,
       "id": "end_stone_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -10840,6 +10918,7 @@
       "count": 6,
       "id": "end_stone_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -11036,6 +11115,7 @@
       "count": 6,
       "id": "exposed_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -11059,6 +11139,7 @@
       "count": 4,
       "id": "exposed_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -12045,6 +12126,7 @@
       "count": 6,
       "id": "granite_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -12068,6 +12150,7 @@
       "count": 4,
       "id": "granite_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -12090,6 +12173,7 @@
       "count": 6,
       "id": "granite_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -13416,6 +13500,7 @@
       "count": 3,
       "id": "iron_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -13689,6 +13774,7 @@
       "count": 1,
       "id": "iron_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -13826,6 +13912,7 @@
       "count": 1,
       "id": "jungle_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -13874,6 +13961,7 @@
       "count": 3,
       "id": "jungle_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -13902,6 +13990,7 @@
       "count": 3,
       "id": "jungle_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -14079,6 +14168,7 @@
       "count": 6,
       "id": "jungle_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -14103,6 +14193,7 @@
       "count": 4,
       "id": "jungle_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -14126,6 +14217,7 @@
       "count": 2,
       "id": "jungle_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -16710,6 +16802,7 @@
       "count": 1,
       "id": "mangrove_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -16758,6 +16851,7 @@
       "count": 3,
       "id": "mangrove_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -16786,6 +16880,7 @@
       "count": 3,
       "id": "mangrove_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -16963,6 +17058,7 @@
       "count": 6,
       "id": "mangrove_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -16987,6 +17083,7 @@
       "count": 4,
       "id": "mangrove_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17010,6 +17107,7 @@
       "count": 2,
       "id": "mangrove_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -17310,6 +17408,7 @@
       "count": 6,
       "id": "mossy_cobblestone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17333,6 +17432,7 @@
       "count": 4,
       "id": "mossy_cobblestone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17355,6 +17455,7 @@
       "count": 6,
       "id": "mossy_cobblestone_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -17376,6 +17477,7 @@
       "count": 6,
       "id": "mossy_stone_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17399,6 +17501,7 @@
       "count": 4,
       "id": "mossy_stone_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17421,6 +17524,7 @@
       "count": 6,
       "id": "mossy_stone_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -17490,6 +17594,7 @@
       "count": 6,
       "id": "mud_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17513,6 +17618,7 @@
       "count": 4,
       "id": "mud_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17535,6 +17641,7 @@
       "count": 6,
       "id": "mud_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -17723,6 +17830,7 @@
       "count": 6,
       "id": "nether_brick_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -17744,6 +17852,7 @@
       "count": 6,
       "id": "nether_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17767,6 +17876,7 @@
       "count": 4,
       "id": "nether_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -17789,6 +17899,7 @@
       "count": 6,
       "id": "nether_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -18080,6 +18191,7 @@
       "count": 1,
       "id": "oak_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -18128,6 +18240,7 @@
       "count": 3,
       "id": "oak_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -18156,6 +18269,7 @@
       "count": 3,
       "id": "oak_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -18333,6 +18447,7 @@
       "count": 6,
       "id": "oak_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -18357,6 +18472,7 @@
       "count": 4,
       "id": "oak_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -18380,6 +18496,7 @@
       "count": 2,
       "id": "oak_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -19052,6 +19169,7 @@
       "count": 6,
       "id": "oxidized_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -19075,6 +19193,7 @@
       "count": 4,
       "id": "oxidized_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -19264,6 +19383,7 @@
       "count": 1,
       "id": "pale_oak_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -19312,6 +19432,7 @@
       "count": 3,
       "id": "pale_oak_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -19340,6 +19461,7 @@
       "count": 3,
       "id": "pale_oak_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -19517,6 +19639,7 @@
       "count": 6,
       "id": "pale_oak_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -19541,6 +19664,7 @@
       "count": 4,
       "id": "pale_oak_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -19564,6 +19688,7 @@
       "count": 2,
       "id": "pale_oak_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -20759,6 +20884,7 @@
       "count": 6,
       "id": "polished_andesite_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -20782,6 +20908,7 @@
       "count": 4,
       "id": "polished_andesite_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -20847,6 +20974,7 @@
       "count": 6,
       "id": "polished_blackstone_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -20870,6 +20998,7 @@
       "count": 4,
       "id": "polished_blackstone_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -20892,6 +21021,7 @@
       "count": 6,
       "id": "polished_blackstone_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -20932,6 +21062,7 @@
       "count": 1,
       "id": "polished_blackstone_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -20974,6 +21105,7 @@
       "count": 6,
       "id": "polished_blackstone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -20997,6 +21129,7 @@
       "count": 4,
       "id": "polished_blackstone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21019,6 +21152,7 @@
       "count": 6,
       "id": "polished_blackstone_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -21062,6 +21196,7 @@
       "count": 6,
       "id": "polished_cinnabar_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21085,6 +21220,7 @@
       "count": 4,
       "id": "polished_cinnabar_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21107,6 +21243,7 @@
       "count": 6,
       "id": "polished_cinnabar_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -21150,6 +21287,7 @@
       "count": 6,
       "id": "polished_deepslate_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21173,6 +21311,7 @@
       "count": 4,
       "id": "polished_deepslate_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21195,6 +21334,7 @@
       "count": 6,
       "id": "polished_deepslate_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -21238,6 +21378,7 @@
       "count": 6,
       "id": "polished_diorite_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21261,6 +21402,7 @@
       "count": 4,
       "id": "polished_diorite_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21304,6 +21446,7 @@
       "count": 6,
       "id": "polished_granite_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21327,6 +21470,7 @@
       "count": 4,
       "id": "polished_granite_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21370,6 +21514,7 @@
       "count": 6,
       "id": "polished_sulfur_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21393,6 +21538,7 @@
       "count": 4,
       "id": "polished_sulfur_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21415,6 +21561,7 @@
       "count": 6,
       "id": "polished_sulfur_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -21458,6 +21605,7 @@
       "count": 6,
       "id": "polished_tuff_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21481,6 +21629,7 @@
       "count": 4,
       "id": "polished_tuff_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21503,6 +21652,7 @@
       "count": 6,
       "id": "polished_tuff_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -21637,6 +21787,7 @@
       "count": 6,
       "id": "prismarine_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21660,6 +21811,7 @@
       "count": 4,
       "id": "prismarine_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21739,6 +21891,7 @@
       "count": 6,
       "id": "prismarine_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21762,6 +21915,7 @@
       "count": 4,
       "id": "prismarine_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -21784,6 +21938,7 @@
       "count": 6,
       "id": "prismarine_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -22334,6 +22489,7 @@
       "count": 6,
       "id": "purpur_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -22358,6 +22514,7 @@
       "count": 4,
       "id": "purpur_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -22447,6 +22604,7 @@
       "count": 6,
       "id": "quartz_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -22472,6 +22630,7 @@
       "count": 4,
       "id": "quartz_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23120,6 +23279,7 @@
       "count": 6,
       "id": "red_nether_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23143,6 +23303,7 @@
       "count": 4,
       "id": "red_nether_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23165,6 +23326,7 @@
       "count": 6,
       "id": "red_nether_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -23236,6 +23398,7 @@
       "count": 6,
       "id": "red_sandstone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23261,6 +23424,7 @@
       "count": 4,
       "id": "red_sandstone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23283,6 +23447,7 @@
       "count": 6,
       "id": "red_sandstone_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -23606,6 +23771,7 @@
       "count": 6,
       "id": "resin_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23629,6 +23795,7 @@
       "count": 4,
       "id": "resin_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23651,6 +23818,7 @@
       "count": 6,
       "id": "resin_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -23823,6 +23991,7 @@
       "count": 6,
       "id": "sandstone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23848,6 +24017,7 @@
       "count": 4,
       "id": "sandstone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -23870,6 +24040,7 @@
       "count": 6,
       "id": "sandstone_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -24325,6 +24496,7 @@
       "count": 6,
       "id": "smooth_quartz_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -24348,6 +24520,7 @@
       "count": 4,
       "id": "smooth_quartz_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -24369,6 +24542,7 @@
       "count": 6,
       "id": "smooth_red_sandstone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -24392,6 +24566,7 @@
       "count": 4,
       "id": "smooth_red_sandstone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -24413,6 +24588,7 @@
       "count": 6,
       "id": "smooth_sandstone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -24436,6 +24612,7 @@
       "count": 4,
       "id": "smooth_sandstone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -24457,6 +24634,7 @@
       "count": 6,
       "id": "smooth_stone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -24779,6 +24957,7 @@
       "count": 1,
       "id": "spruce_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -24827,6 +25006,7 @@
       "count": 3,
       "id": "spruce_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -24855,6 +25035,7 @@
       "count": 3,
       "id": "spruce_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -25032,6 +25213,7 @@
       "count": 6,
       "id": "spruce_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -25056,6 +25238,7 @@
       "count": 4,
       "id": "spruce_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -25079,6 +25262,7 @@
       "count": 2,
       "id": "spruce_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -25267,6 +25451,7 @@
       "count": 6,
       "id": "stone_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -25290,6 +25475,7 @@
       "count": 4,
       "id": "stone_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -25312,6 +25498,7 @@
       "count": 6,
       "id": "stone_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -25352,6 +25539,7 @@
       "count": 1,
       "id": "stone_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -25487,6 +25675,7 @@
       "count": 6,
       "id": "stone_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -25541,6 +25730,7 @@
       "count": 4,
       "id": "stone_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -25911,6 +26101,7 @@
       "count": 6,
       "id": "sulfur_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -25934,6 +26125,7 @@
       "count": 4,
       "id": "sulfur_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -25956,6 +26148,7 @@
       "count": 6,
       "id": "sulfur_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -26021,6 +26214,7 @@
       "count": 6,
       "id": "sulfur_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -26044,6 +26238,7 @@
       "count": 4,
       "id": "sulfur_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -26066,6 +26261,7 @@
       "count": 6,
       "id": "sulfur_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -26915,6 +27111,7 @@
       "count": 6,
       "id": "tuff_brick_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -26938,6 +27135,7 @@
       "count": 4,
       "id": "tuff_brick_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -26960,6 +27158,7 @@
       "count": 6,
       "id": "tuff_brick_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -27003,6 +27202,7 @@
       "count": 6,
       "id": "tuff_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -27026,6 +27226,7 @@
       "count": 4,
       "id": "tuff_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -27048,6 +27249,7 @@
       "count": 6,
       "id": "tuff_wall"
     },
+    "shapeTag": "walls",
     "slug": "default",
     "type": "shaped"
   },
@@ -27155,6 +27357,7 @@
       "count": 1,
       "id": "warped_button"
     },
+    "shapeTag": "buttons",
     "slug": "default",
     "type": "shapeless"
   },
@@ -27179,6 +27382,7 @@
       "count": 3,
       "id": "warped_door"
     },
+    "shapeTag": "doors",
     "slug": "default",
     "type": "shaped"
   },
@@ -27207,6 +27411,7 @@
       "count": 3,
       "id": "warped_fence"
     },
+    "shapeTag": "fences",
     "slug": "default",
     "type": "shaped"
   },
@@ -27434,6 +27639,7 @@
       "count": 6,
       "id": "warped_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -27458,6 +27664,7 @@
       "count": 4,
       "id": "warped_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -27481,6 +27688,7 @@
       "count": 2,
       "id": "warped_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "default",
     "type": "shaped"
   },
@@ -27706,6 +27914,7 @@
       "count": 1,
       "id": "waxed_copper_door"
     },
+    "shapeTag": "doors",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -27826,6 +28035,7 @@
       "count": 1,
       "id": "waxed_copper_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -27895,6 +28105,7 @@
       "count": 6,
       "id": "waxed_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -27919,6 +28130,7 @@
       "count": 1,
       "id": "waxed_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -27943,6 +28155,7 @@
       "count": 4,
       "id": "waxed_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -27967,6 +28180,7 @@
       "count": 1,
       "id": "waxed_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -28168,6 +28382,7 @@
       "count": 1,
       "id": "waxed_exposed_copper_door"
     },
+    "shapeTag": "doors",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -28312,6 +28527,7 @@
       "count": 1,
       "id": "waxed_exposed_copper_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -28381,6 +28597,7 @@
       "count": 6,
       "id": "waxed_exposed_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -28405,6 +28622,7 @@
       "count": 1,
       "id": "waxed_exposed_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -28429,6 +28647,7 @@
       "count": 4,
       "id": "waxed_exposed_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -28453,6 +28672,7 @@
       "count": 1,
       "id": "waxed_exposed_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -28702,6 +28922,7 @@
       "count": 1,
       "id": "waxed_oxidized_copper_door"
     },
+    "shapeTag": "doors",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -28846,6 +29067,7 @@
       "count": 1,
       "id": "waxed_oxidized_copper_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -28915,6 +29137,7 @@
       "count": 6,
       "id": "waxed_oxidized_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -28939,6 +29162,7 @@
       "count": 1,
       "id": "waxed_oxidized_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -28963,6 +29187,7 @@
       "count": 4,
       "id": "waxed_oxidized_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -28987,6 +29212,7 @@
       "count": 1,
       "id": "waxed_oxidized_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -29212,6 +29438,7 @@
       "count": 1,
       "id": "waxed_weathered_copper_door"
     },
+    "shapeTag": "doors",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -29356,6 +29583,7 @@
       "count": 1,
       "id": "waxed_weathered_copper_trapdoor"
     },
+    "shapeTag": "trapdoors",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -29425,6 +29653,7 @@
       "count": 6,
       "id": "waxed_weathered_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -29449,6 +29678,7 @@
       "count": 1,
       "id": "waxed_weathered_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -29473,6 +29703,7 @@
       "count": 4,
       "id": "waxed_weathered_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },
@@ -29497,6 +29728,7 @@
       "count": 1,
       "id": "waxed_weathered_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "from-honeycomb",
     "type": "shapeless"
   },
@@ -29677,6 +29909,7 @@
       "count": 6,
       "id": "weathered_cut_copper_slab"
     },
+    "shapeTag": "slabs",
     "slug": "default",
     "type": "shaped"
   },
@@ -29700,6 +29933,7 @@
       "count": 4,
       "id": "weathered_cut_copper_stairs"
     },
+    "shapeTag": "stairs",
     "slug": "default",
     "type": "shaped"
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -268,10 +268,20 @@ const totalCards = cards.length;
           </h2>
           {category.families.map((family) => (
             <div class="catalog__family-group" data-family-group={family.familyId}>
-              <h3 class="catalog__family-title">
-                {family.familyName}{' '}
-                <span class="catalog__family-group-count">({family.cards.length})</span>
-              </h3>
+              {
+                // A family that collapsed to a single card (e.g. Signs,
+                // Hanging Signs, Shelves -- every vanilla variant is wood-only,
+                // so there's nothing left to distinguish within this section)
+                // doesn't need its own heading repeating a count of 1 -- the
+                // card's own name already says what it is. Multi-card families
+                // keep the heading, which is what makes the section scannable.
+                family.cards.length > 1 && (
+                  <h3 class="catalog__family-title">
+                    {family.familyName}{' '}
+                    <span class="catalog__family-group-count">({family.cards.length})</span>
+                  </h3>
+                )
+              }
               <ul class="catalog__grid">
                 {family.cards.map((card) => (
                   <li

--- a/src/pages/variant-icons.json.ts
+++ b/src/pages/variant-icons.json.ts
@@ -28,9 +28,9 @@ import {
  * index.astro's applyTextures.
  *
  * Not every group's members are actually geometry-identical (see
- * isIconGeometryUniform's doc comment -- wooden_trapdoor's oak/dark_oak
- * members use a different uv template than its other 10 woods, a real
- * vanilla data split). For a non-uniform group, every member gets an empty
+ * isIconGeometryUniform's doc comment -- the "trapdoors" group's oak/
+ * dark_oak members use a different uv template than every other wood, a
+ * real vanilla data split). For a non-uniform group, every member gets an empty
  * `textures` array instead -- the client treats that as "no swap data" and
  * leaves the card showing its curated default, rather than risk swapping in
  * a mismatched crop.

--- a/src/utils/icon-faces.ts
+++ b/src/utils/icon-faces.ts
@@ -121,15 +121,18 @@ function iconGeometryFingerprint(icon: IconData): unknown {
  * iconGeometryFingerprint), i.e. whether iconSwapTextures' texture-URL-only
  * swap is safe for this group. This does NOT always hold: verified against
  * the real generated data (see tests/icon-faces.test.ts's regression test),
- * 41 of 42 current variant groups pass, but wooden_trapdoor's oak/dark_oak
- * members use vanilla's legacy non-orientable trapdoor template (different
- * per-face uv rects -- flipped/offset top and side crops) while its other 10
- * woods use the newer orientable template -- a real vanilla data split, not
- * a pipeline bug (see scripts/lib/model.ts and vendor/mcmeta-summary's
- * template_trapdoor_bottom vs template_orientable_trapdoor_bottom). A future
- * mcmeta version bump could introduce a similar split in a currently-uniform
- * group; this check lets a caller (variant-icons.json.ts) degrade that one
- * group safely (omit its swap textures) without a hand-maintained denylist.
+ * all current variant groups pass except "trapdoors" (see
+ * src/utils/recipe-groups.ts's shapeTag-derived collapse -- this group now
+ * spans every wood + iron + copper trapdoor, not just the 12 wood ones),
+ * whose oak/dark_oak members use vanilla's legacy non-orientable trapdoor
+ * template (different per-face uv rects -- flipped/offset top and side
+ * crops) while every other wood uses the newer orientable template -- a real
+ * vanilla data split, not a pipeline bug (see scripts/lib/model.ts and
+ * vendor/mcmeta-summary's template_trapdoor_bottom vs
+ * template_orientable_trapdoor_bottom). A future mcmeta version bump could
+ * introduce a similar split in a currently-uniform group; this check lets a
+ * caller (variant-icons.json.ts) degrade that one group safely (omit its
+ * swap textures) without a hand-maintained denylist.
  */
 export function isIconGeometryUniform(icons: IconData[]): boolean {
   if (icons.length <= 1) return true;

--- a/src/utils/recipe-groups.ts
+++ b/src/utils/recipe-groups.ts
@@ -112,7 +112,7 @@ export interface RecipeGroup {
   resultId: string;
   family: string;
   familyId: string;
-  /** This result's collapse key -- an id-derived oxidation/waxing base (see stripOxidationPrefixes) when one applies, else the normalized vanilla `group` field shared by this result's recipes (see normalizeVariantGroupKey), else undefined. Used to fold same-shape/different-material result items into one tabbed VariantGroup -- see collapseVariantGroups. */
+  /** This result's collapse key, highest-precedence source wins: (1) the data-pipeline-derived shape-tag key (see scripts/lib/shape-tag.ts's deriveShapeTag, persisted as recipe.shapeTag) when the result belongs to an allow-listed vanilla shape tag -- the most complete signal, since it unifies every material of a shape (wood, stone, AND copper) in one pass; (2) an id-derived oxidation/waxing base (see stripOxidationPrefixes) for copper shapes no shape tag covers; (3) the normalized vanilla `group` field shared by this result's recipes (see normalizeVariantGroupKey); else undefined. Used to fold same-shape/different-material result items into one tabbed VariantGroup -- see collapseVariantGroups. Precedence example: cut_copper_slab is both in `#minecraft:slabs` (shapeTag) and oxidation-collapsible with its own tiers -- shapeTag wins, so it joins the single "Slabs" card (with oak_slab, stone_slab, ...) rather than a standalone "Cut Copper Slab" card of just its 8 tiers (see tests/recipe-groups.test.ts). */
   variantKey: string | undefined;
   /** Alphabetically-first recipe id — the group's default/linked-to recipe. */
   canonicalId: string;
@@ -268,9 +268,13 @@ export function groupRecipes(
     }
 
     const strippedResultId = stripOxidationPrefixes(resultId);
-    const variantKey = oxidationBases.has(strippedResultId)
-      ? strippedResultId
-      : normalizeVariantGroupKey(members[0].group);
+    // Precedence: shapeTag (data-pipeline, tag-derived) > oxidation-strip >
+    // vanilla `group` -- see RecipeGroup.variantKey's doc comment above for
+    // why and the cut_copper_slab example this order resolves.
+    const variantKey =
+      members[0].shapeTag ??
+      (oxidationBases.has(strippedResultId) ? strippedResultId : undefined) ??
+      normalizeVariantGroupKey(members[0].group);
 
     groups.push({
       resultId,
@@ -374,41 +378,55 @@ export const VARIANT_GROUP_META: Record<string, VariantGroupMeta> = {
   stained_glass_pane: { name: "Stained Glass Pane", defaultResultId: "white_stained_glass_pane" },
   stained_terracotta: { name: "Dyed Terracotta", defaultResultId: "white_terracotta" },
   wool: { name: "Wool", defaultResultId: "white_wool" },
-  // Wood families -- default to oak, the wood type most players picture first.
+  // Wood-only families -- default to oak, the wood type most players
+  // picture first. Each of these stays keyed by vanilla's own `group`
+  // field: no non-wood sibling exists in vanilla for any of them today
+  // (see scripts/lib/shape-tag.ts's doc comment for the confirmed sweep),
+  // so there's nothing for a shapeTag rule to unify beyond what `group`
+  // already achieves.
   bark: { name: "Wood & Hyphae", defaultResultId: "oak_wood" },
   boat: { name: "Boat", defaultResultId: "oak_boat" },
   chest_boat: { name: "Boat with Chest", defaultResultId: "oak_chest_boat" },
   planks: { name: "Planks", defaultResultId: "oak_planks" },
   shelf: { name: "Shelf", defaultResultId: "oak_shelf" },
-  wooden_button: { name: "Wooden Button", defaultResultId: "oak_button" },
-  wooden_door: { name: "Wooden Door", defaultResultId: "oak_door" },
-  wooden_fence: { name: "Wooden Fence", defaultResultId: "oak_fence" },
   wooden_fence_gate: { name: "Fence Gate", defaultResultId: "oak_fence_gate" },
   wooden_hanging_sign: { name: "Hanging Sign", defaultResultId: "oak_hanging_sign" },
   wooden_pressure_plate: { name: "Wooden Pressure Plate", defaultResultId: "oak_pressure_plate" },
   wooden_sign: { name: "Sign", defaultResultId: "oak_sign" },
-  wooden_slab: { name: "Wooden Slab", defaultResultId: "oak_slab" },
-  wooden_stairs: { name: "Wooden Stairs", defaultResultId: "oak_stairs" },
-  wooden_trapdoor: { name: "Wooden Trapdoor", defaultResultId: "oak_trapdoor" },
+  // Shape families collapsed via vanilla item tags (see
+  // scripts/lib/shape-tag.ts) -- every material Mojang ships for the
+  // shape lands in one card, wood included, so these default the same way
+  // the wood-only families above do: oak, except walls (no vanilla wooden
+  // wall exists -- cobblestone is the earliest-game, most iconic wall
+  // material instead).
+  buttons: { name: "Buttons", defaultResultId: "oak_button" },
+  doors: { name: "Doors", defaultResultId: "oak_door" },
+  fences: { name: "Fences", defaultResultId: "oak_fence" },
+  slabs: { name: "Slabs", defaultResultId: "oak_slab" },
+  stairs: { name: "Stairs", defaultResultId: "oak_stairs" },
+  trapdoors: { name: "Trapdoors", defaultResultId: "oak_trapdoor" },
+  walls: { name: "Walls", defaultResultId: "cobblestone_wall" },
   // Copper oxidation families -- default to the clean, un-oxidized base
-  // tier (golem_statue has no base-tier recipe, so its earliest waxed tier).
+  // tier (golem_statue has no base-tier recipe, so its earliest waxed
+  // tier). Doesn't include cut_copper_slab/cut_copper_stairs/copper_door/
+  // copper_trapdoor: those shapes now collapse under the "slabs"/"stairs"/
+  // "doors"/"trapdoors" shapeTag keys above instead (see
+  // src/utils/recipe-groups.ts's groupRecipes precedence), folding their
+  // copper tiers in with every other material of the same shape rather
+  // than keeping copper on its own separate card.
   chiseled_copper: { name: "Chiseled Copper", defaultResultId: "chiseled_copper" },
   copper_bars: { name: "Copper Bars", defaultResultId: "copper_bars" },
   copper_block: { name: "Block of Copper", defaultResultId: "copper_block" },
   copper_bulb: { name: "Copper Bulb", defaultResultId: "copper_bulb" },
   copper_chain: { name: "Copper Chain", defaultResultId: "copper_chain" },
   copper_chest: { name: "Copper Chest", defaultResultId: "copper_chest" },
-  copper_door: { name: "Copper Door", defaultResultId: "copper_door" },
   copper_golem_statue: {
     name: "Copper Golem Statue",
     defaultResultId: "waxed_copper_golem_statue",
   },
   copper_grate: { name: "Copper Grate", defaultResultId: "copper_grate" },
   copper_lantern: { name: "Copper Lantern", defaultResultId: "copper_lantern" },
-  copper_trapdoor: { name: "Copper Trapdoor", defaultResultId: "copper_trapdoor" },
   cut_copper: { name: "Cut Copper", defaultResultId: "cut_copper" },
-  cut_copper_slab: { name: "Cut Copper Slab", defaultResultId: "cut_copper_slab" },
-  cut_copper_stairs: { name: "Cut Copper Stairs", defaultResultId: "cut_copper_stairs" },
   lightning_rod: { name: "Lightning Rod", defaultResultId: "lightning_rod" },
   // Synthetic entries (see scripts/lib/patterned-banner.ts) -- creeper is
   // the iconic pattern, the one most players picture first.

--- a/tests/icon-faces.test.ts
+++ b/tests/icon-faces.test.ts
@@ -217,16 +217,18 @@ describe("isIconGeometryUniform", () => {
     expect(isIconGeometryUniform([base, differentYRotation])).toBe(false);
   });
 
-  it("loads the real generated data and confirms every variant group is geometry-uniform except the known wooden_trapdoor split", async () => {
-    // wooden_trapdoor: oak/dark_oak parent to vanilla's legacy
-    // template_trapdoor_bottom (non-orientable uv); the other 10 woods
-    // parent to the newer template_orientable_trapdoor_bottom -- a real
-    // vanilla data split (verified against vendor/mcmeta-summary), not a
-    // pipeline bug. variant-icons.json.ts's isIconGeometryUniform check
-    // already degrades this one group safely (empty swap textures); this
-    // test's real job is failing loudly if a FUTURE mcmeta bump introduces
-    // a similar split in some other, currently-uniform group.
-    const KNOWN_NONUNIFORM_GROUPS = new Set(["wooden_trapdoor"]);
+  it("loads the real generated data and confirms every variant group is geometry-uniform except the known trapdoors split", async () => {
+    // trapdoors (see src/utils/recipe-groups.ts's shapeTag-derived collapse --
+    // every wood + iron + copper trapdoor is one group now, not just the 12
+    // wood ones): oak/dark_oak parent to vanilla's legacy
+    // template_trapdoor_bottom (non-orientable uv); every other wood parents
+    // to the newer template_orientable_trapdoor_bottom -- a real vanilla data
+    // split (verified against vendor/mcmeta-summary), not a pipeline bug.
+    // variant-icons.json.ts's isIconGeometryUniform check already degrades
+    // this one group safely (empty swap textures); this test's real job is
+    // failing loudly if a FUTURE mcmeta bump introduces a similar split in
+    // some other, currently-uniform group.
+    const KNOWN_NONUNIFORM_GROUPS = new Set(["trapdoors"]);
 
     const recipesModule = await import("../src/data/generated/recipes.json");
     const itemsModule = await import("../src/data/generated/items.json");
@@ -255,7 +257,7 @@ describe("isIconGeometryUniform", () => {
     // The known exception must still actually be non-uniform -- if a future
     // mcmeta bump ever normalizes oak/dark_oak onto the orientable template,
     // this should fail so the exception list gets cleaned up, not left stale.
-    const trapdoorGroup = variantGroups.find((vg) => vg.groupKey === "wooden_trapdoor");
+    const trapdoorGroup = variantGroups.find((vg) => vg.groupKey === "trapdoors");
     if (trapdoorGroup) {
       const icons = trapdoorGroup.variants
         .map((v) => items[v.resultId]?.icon)

--- a/tests/recipe-groups.test.ts
+++ b/tests/recipe-groups.test.ts
@@ -421,17 +421,30 @@ describe("collapseVariantGroups: copper oxidation-tier grouping", () => {
     const groups = groupRecipes(allRecipes, itemName);
     const { variantGroups } = collapseVariantGroups(groups);
 
-    for (const shape of [
-      "cut_copper",
-      "cut_copper_slab",
-      "cut_copper_stairs",
-      "copper_bulb",
-      "copper_grate",
-    ]) {
+    // cut_copper (the block itself, not a slab/stairs) plus copper_bulb/
+    // copper_grate carry no shapeTag (no vendored tag unifies them across
+    // materials -- see scripts/lib/shape-tag.ts), so they stay on the
+    // oxidation-only derivation: an 8-member group of just their own tiers.
+    for (const shape of ["cut_copper", "copper_bulb", "copper_grate"]) {
       const vg = variantGroups.find((v) => v.groupKey === shape);
       expect(vg, `expected a VariantGroup for "${shape}"`).toBeDefined();
       expect(vg!.variants.length).toBe(8);
     }
+
+    // cut_copper_slab/cut_copper_stairs are DIFFERENT: they're both
+    // oxidation-collapsible (own tiers) AND in #minecraft:slabs/#stairs
+    // (shapeTag) -- shapeTag wins (see RecipeGroup.variantKey's precedence
+    // doc comment), so they're no longer their own standalone 8-member
+    // groups; they're folded into the shape-wide "slabs"/"stairs" groups
+    // alongside every other material.
+    expect(variantGroups.find((vg) => vg.groupKey === "cut_copper_slab")).toBeUndefined();
+    expect(variantGroups.find((vg) => vg.groupKey === "cut_copper_stairs")).toBeUndefined();
+    const slabsGroup = variantGroups.find((vg) => vg.groupKey === "slabs");
+    const stairsGroup = variantGroups.find((vg) => vg.groupKey === "stairs");
+    expect(slabsGroup?.variants.map((v) => v.resultId)).toContain("cut_copper_slab");
+    expect(slabsGroup?.variants.map((v) => v.resultId)).toContain("oak_slab");
+    expect(stairsGroup?.variants.map((v) => v.resultId)).toContain("cut_copper_stairs");
+    expect(stairsGroup?.variants.map((v) => v.resultId)).toContain("oak_stairs");
 
     expect(variantGroups.find((vg) => vg.groupKey === "dyed_armor")).toBeUndefined();
     for (const resultId of [
@@ -443,6 +456,75 @@ describe("collapseVariantGroups: copper oxidation-tier grouping", () => {
       const group = groups.find((g) => g.resultId === resultId);
       expect(group?.variantKey, `${resultId} must never get a variantKey`).toBeUndefined();
     }
+  });
+});
+
+describe("groupRecipes: shapeTag precedence over oxidation-strip and vanilla group", () => {
+  // cut_copper_slab is the real case this precedence resolves: it's both
+  // oxidation-collapsible (its own 8 waxing/exposure tiers) AND a member of
+  // #minecraft:slabs (shapeTag, persisted by scripts/lib/shape-tag.ts) --
+  // shapeTag must win, so it joins the single shape-wide "Slabs" card
+  // (oak_slab, stone_slab, ...) rather than a standalone "Cut Copper Slab"
+  // card of just its own tiers. Reproduced here against a minimal synthetic
+  // fixture (not just the real-data integration test above) so the
+  // precedence rule itself is pinned independent of what the current mcmeta
+  // pin happens to contain.
+  it("prefers shapeTag over an oxidation-eligible id, folding a copper shape into the shape-wide group", () => {
+    const recipes: RecipeData[] = [
+      recipe({
+        id: "oak_slab",
+        group: "wooden_slab",
+        shapeTag: "slabs",
+        result: { id: "oak_slab", count: 6 },
+        ingredients: [{ items: ["oak_planks"] }],
+      }),
+      recipe({
+        id: "stone_slab",
+        shapeTag: "slabs",
+        result: { id: "stone_slab", count: 6 },
+        ingredients: [{ items: ["stone"] }],
+      }),
+      // Both oxidation-eligible (siblings below share its stripped id) AND
+      // tagged into the same shape as oak_slab/stone_slab above.
+      recipe({
+        id: "cut_copper_slab",
+        shapeTag: "slabs",
+        result: { id: "cut_copper_slab", count: 6 },
+        ingredients: [{ items: ["cut_copper"] }],
+      }),
+      recipe({
+        id: "exposed_cut_copper_slab",
+        shapeTag: "slabs",
+        result: { id: "exposed_cut_copper_slab", count: 6 },
+        ingredients: [{ items: ["exposed_cut_copper"] }],
+      }),
+      recipe({
+        id: "waxed_cut_copper_slab",
+        shapeTag: "slabs",
+        result: { id: "waxed_cut_copper_slab", count: 1 },
+        ingredients: [{ items: ["honeycomb"] }, { items: ["cut_copper_slab"] }],
+      }),
+    ];
+
+    const groups = groupRecipes(recipes, itemName);
+    const { variantGroups, singletons } = collapseVariantGroups(groups);
+
+    // Not stranded on its own oxidation-only key ("cut_copper_slab") --
+    // that key never appears as a real groupKey once shapeTag applies.
+    expect(variantGroups.find((vg) => vg.groupKey === "cut_copper_slab")).toBeUndefined();
+    expect(singletons.find((g) => g.resultId === "cut_copper_slab")).toBeUndefined();
+
+    const slabsGroup = variantGroups.find((vg) => vg.groupKey === "slabs");
+    expect(slabsGroup, 'expected one "slabs" VariantGroup').toBeDefined();
+    expect(slabsGroup!.variants.map((v) => v.resultId).toSorted()).toEqual(
+      [
+        "oak_slab",
+        "stone_slab",
+        "cut_copper_slab",
+        "exposed_cut_copper_slab",
+        "waxed_cut_copper_slab",
+      ].toSorted(),
+    );
   });
 });
 

--- a/tests/shape-tag.test.ts
+++ b/tests/shape-tag.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { buildItemTagIndex } from "../scripts/lib/family.ts";
+import { deriveShapeTag } from "../scripts/lib/shape-tag.ts";
+import type { RawTagsData, RecipesOutput } from "../scripts/lib/types.ts";
+
+describe("deriveShapeTag", () => {
+  it("returns the shape tag for an item directly listed in it", () => {
+    const tags: RawTagsData = {
+      slabs: { values: ["minecraft:stone_slab", "minecraft:cut_copper_slab"] },
+    };
+    const index = buildItemTagIndex(tags);
+
+    expect(deriveShapeTag("stone_slab", index)).toBe("slabs");
+    expect(deriveShapeTag("cut_copper_slab", index)).toBe("slabs");
+  });
+
+  it("resolves through a nested #wooden_X sub-tag, matching vanilla's real slabs/stairs/etc shape", () => {
+    const tags: RawTagsData = {
+      wooden_slabs: { values: ["minecraft:oak_slab", "minecraft:spruce_slab"] },
+      slabs: { values: ["#minecraft:wooden_slabs", "minecraft:stone_slab"] },
+    };
+    const index = buildItemTagIndex(tags);
+
+    expect(deriveShapeTag("oak_slab", index)).toBe("slabs");
+    expect(deriveShapeTag("stone_slab", index)).toBe("slabs");
+  });
+
+  it("returns undefined for an item not in any allow-listed shape tag", () => {
+    const tags: RawTagsData = { slabs: { values: ["minecraft:stone_slab"] } };
+    const index = buildItemTagIndex(tags);
+
+    expect(deriveShapeTag("torch", index)).toBeUndefined();
+  });
+
+  it("returns undefined for an item in a real vanilla tag that ISN'T on the shape allowlist -- e.g. 'copper', which spans several different shapes, not material variants of one shape", () => {
+    const tags: RawTagsData = {
+      copper: {
+        values: ["minecraft:copper_block", "minecraft:lightning_rod", "minecraft:copper_bulb"],
+      },
+    };
+    const index = buildItemTagIndex(tags);
+
+    expect(deriveShapeTag("copper_block", index)).toBeUndefined();
+    expect(deriveShapeTag("lightning_rod", index)).toBeUndefined();
+  });
+
+  it("returns undefined when no tag data was indexed for this item at all", () => {
+    const index = buildItemTagIndex({});
+    expect(deriveShapeTag("oak_slab", index)).toBeUndefined();
+  });
+});
+
+describe("real generated data — shapeTag persistence and coverage", () => {
+  const recipes: RecipesOutput = JSON.parse(
+    readFileSync(join(import.meta.dirname, "../src/data/generated/recipes.json"), "utf8"),
+  );
+
+  it("persists shapeTag onto every current shape family's real result items", () => {
+    const byShapeTag = new Map<string, Set<string>>();
+    for (const recipe of Object.values(recipes)) {
+      if (!recipe.shapeTag || !recipe.result) continue;
+      const set = byShapeTag.get(recipe.shapeTag) ?? new Set<string>();
+      set.add(recipe.result.id);
+      byShapeTag.set(recipe.shapeTag, set);
+    }
+
+    // Every allow-listed shape currently has real vanilla members in the
+    // pinned mcmeta version -- if any of these ever comes back empty, either
+    // the allowlist or the vendored tag data has drifted and needs a look.
+    for (const shape of ["slabs", "stairs", "walls", "buttons", "doors", "trapdoors", "fences"]) {
+      expect(byShapeTag.get(shape)?.size ?? 0, `expected real "${shape}" members`).toBeGreaterThan(
+        0,
+      );
+    }
+
+    // Wood + a non-wood material both land under "slabs" -- the concrete
+    // proof that this is a real cross-material collapse, not just a rename
+    // of the old wood-only "wooden_slab" group.
+    expect(byShapeTag.get("slabs")?.has("oak_slab")).toBe(true);
+    expect(byShapeTag.get("slabs")?.has("stone_slab")).toBe(true);
+  });
+
+  it("never assigns a shapeTag to a shape deliberately left off the allowlist (pressure plates -- no vendored cross-material tag exists)", () => {
+    const stonePressurePlates = [
+      "stone_pressure_plate",
+      "polished_blackstone_pressure_plate",
+      "heavy_weighted_pressure_plate",
+      "light_weighted_pressure_plate",
+    ];
+    for (const id of stonePressurePlates) {
+      const recipe = Object.values(recipes).find((r) => r.result?.id === id);
+      expect(recipe?.shapeTag, `${id} should have no shapeTag`).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Homepage cards collapsed via vanilla's recipe `group` field, which Mojang only writes for wood variants — so stone/mineral variants never collapsed (Slabs: 63 items → 49 cards; Walls: 32 → 32, zero collapse) while all-wood families (signs, shelves) collapsed to a single lonely card under its own heading. One mechanism, three-part data-backed fix:

1. **Tag-derived collapse key, persisted by the pipeline.** `scripts/lib/shape-tag.ts` (new) derives a `shapeTag` from vendored vanilla item tags (`#slabs`, `#stairs`, `#walls`, `#buttons`, `#doors`, `#trapdoors`, `#fences`) and persists it onto each recipe in generated data. Precedence in `recipe-groups.ts` is `shapeTag → oxidation-strip → vanilla group`, covered by dedicated Vitest cases (cut-copper slabs are both tag-members and oxidation-collapsible — shapeTag wins so the Slabs card is complete at 67 variants). New variants Mojang ships auto-join via tag membership: zero code on a data bump.
2. **Compact variant picker.** Past 20 variants the equal chip row becomes a dense icon-only grid — pure CSS, labels move to `title` tooltips + visually-hidden accessible names.
3. **Lonely-section fix.** Homepage sections with exactly one card no longer render a redundant heading.

Card counts: Slabs 49→1, Stairs 46→1, Walls 32→1, Buttons 3→1, Doors/Trapdoors →1 each, Fences 2→1. Homepage total 520 → 389 cards.

Deliberately NOT collapsed: pressure plates — vanilla ships no tag unifying them across materials (only `#wooden_pressure_plates` exists), and a hand-maintained list would break the data-backed rule. Documented in `shape-tag.ts`. Wood-only families (signs, hanging signs, fence gates, shelves) aren't routed through the mechanism since membership wouldn't change today; add their tag the day a non-wood member ships.

Also: the pre-existing `wooden_trapdoor` known-non-uniform-icon exception renamed to `trapdoors` (same oak/dark_oak legacy quirk, now inside the merged group); `docs/PLAN.md` documents the `shapeTag` contract addition.

## Verification

format / type-check / lint / test (348/348) / parse (zero drift post-rebase) / validate / build (1163 pages) — all green after rebase onto #54–#60. JS bundle unchanged (~5.9 kB gzip, picker is pure CSS).

https://claude.ai/code/session_013ga8yb2vDELdU9x9zZPDtA